### PR TITLE
Fix accidental export, update docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+FEATURES := nightly
+
+doc:
+	cargo rustdoc --features "$(FEATURES)" -- --html-in-header docs/assets/rustdoc-include-katex-header.html
+
+doc-internal:
+	cargo rustdoc --features "$(FEATURES)" -- --html-in-header docs/assets/rustdoc-include-katex-header.html --document-private-items
+

--- a/docs/assets/rustdoc-include-katex-header.html
+++ b/docs/assets/rustdoc-include-katex-header.html
@@ -1,0 +1,10 @@
+<link rel="stylesheet" href="https://doc.dalek.rs/assets/katex/katex.min.css">
+<script src="https://doc.dalek.rs/assets/katex/katex.min.js"></script>
+<script src="https://doc.dalek.rs/assets/katex/contrib/auto-render.min.js"></script>
+<script>
+document.addEventListener("DOMContentLoaded", function() { renderMathInElement(document.body); });
+</script>
+<style>
+.katex { font-size: 1em !important; }
+pre.rust, .docblock code, .docblock-short code { font-size: 0.85em !important; }
+</style>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,11 @@
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 #![cfg_attr(feature = "nightly", feature(asm))]
 
+#![doc(html_logo_url = "https://doc.dalek.rs/assets/dalek-logo-clear.png")]
+
+//! Note that docs will only build on nightly Rust until
+//! [RFC 1990 stabilizes](https://github.com/rust-lang/rust/issues/44732).
+
 #[cfg(feature = "std")]
 extern crate core;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,21 @@ use core::ops::Neg;
 /// `Choice` passes the value through an optimization barrier, as a
 /// best-effort attempt to prevent the compiler from inferring that the
 /// `Choice` value is a boolean.
+///
+/// The `Choice` struct implements operators for AND, OR, XOR, and
+/// NOT, to allow combining `Choice` values.
+/// These operations do not short-circuit.
 #[derive(Copy, Clone)]
 pub struct Choice(u8);
 
 impl Choice {
     /// Unwrap the `Choice` wrapper to reveal the underlying `u8`.
+    ///
+    /// # Note
+    ///
+    /// This function only exists as an escape hatch for the rare case
+    /// where it's not possible to use one of the `subtle`-provided
+    /// trait impls.
     #[inline]
     pub fn unwrap_u8(&self) -> u8 {
         self.0


### PR DESCRIPTION
One of the internal functions was accidentally exported.  This changeset makes it private and updates the docs.