### PR TITLE
Always use the #![no_std] directive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 // - Isis Agora Lovecruft <isis@patternsinthevoid.net>
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![cfg_attr(feature = "nightly", feature(asm))]
 #![cfg_attr(feature = "nightly", feature(external_doc))]
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
@@ -20,7 +20,7 @@
 //! [RFC 1990 stabilizes](https://github.com/rust-lang/rust/issues/44732).
 
 #[cfg(feature = "std")]
-extern crate core;
+extern crate std;
 
 use core::ops::{BitAnd, BitOr, BitXor, Not};
 


### PR DESCRIPTION
This ensures `std` and `no_std` consistently import the same crates, and makes adding `std` purely positive.

It's also a bit more straightforward and a pattern I'd like to encourage.