### PR TITLE
Additional impls for Conditional* traits for tuples and slices.

### DIFF
--- a/fuzz/fuzzers/conditional_assign_i128.rs
+++ b/fuzz/fuzzers/conditional_assign_i128.rs
@@ -1,5 +1,4 @@
 #![no_main]
-#![feature(i128_type)]
 
 #[macro_use]
 extern crate libfuzzer_sys;
@@ -26,10 +25,10 @@ fuzz_target!(|data: &[u8]| {
                 bytes[8],  bytes[9],  bytes[10], bytes[11],
                 bytes[12], bytes[13], bytes[14], bytes[15]]);
 
-            x.conditional_assign(&y, 0);
+            x.conditional_assign(&y, 0.into());
             assert_eq!(x, 0);
 
-            x.conditional_assign(&y, 1);
+            x.conditional_assign(&y, 1.into());
             assert_eq!(x, y);
         }
     }

--- a/fuzz/fuzzers/conditional_assign_i8.rs
+++ b/fuzz/fuzzers/conditional_assign_i8.rs
@@ -15,10 +15,10 @@ fuzz_target!(|data: &[u8]| {
             let mut x: i8 = 0;
             let y: i8 = transmute::<u8, i8>(*y);
 
-            x.conditional_assign(&y, 0);
+            x.conditional_assign(&y, 0.into());
             assert_eq!(x, 0);
 
-            x.conditional_assign(&y, 1);
+            x.conditional_assign(&y, 1.into());
             assert_eq!(x, y);
         }
     }

--- a/fuzz/fuzzers/conditional_assign_u16.rs
+++ b/fuzz/fuzzers/conditional_assign_u16.rs
@@ -21,10 +21,10 @@ fuzz_target!(|data: &[u8]| {
             let mut x: u16 = 0;
             let y: u16 = transmute::<[u8; 2], u16>([bytes[0], bytes[1]]);
 
-            x.conditional_assign(&y, 0);
+            x.conditional_assign(&y, 0.into());
             assert_eq!(x, 0);
 
-            x.conditional_assign(&y, 1);
+            x.conditional_assign(&y, 1.into());
             assert_eq!(x, y);
         }
     }

--- a/fuzz/fuzzers/conditional_assign_u8.rs
+++ b/fuzz/fuzzers/conditional_assign_u8.rs
@@ -11,10 +11,10 @@ fuzz_target!(|data: &[u8]| {
     for y in data.iter() {
         let mut x: u8 = 0;
 
-        x.conditional_assign(y, 0);
+        x.conditional_assign(y, 0.into());
         assert_eq!(x, 0);
 
-        x.conditional_assign(y, 1);
+        x.conditional_assign(y, 1.into());
         assert_eq!(x, *y);
     }
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -580,7 +580,88 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "generic-impls")]
+    fn conditional_select_u8() {
+        for i in 0..=::std::u8::MAX {
+            for j in 0..=::std::u8::MAX {
+                assert_eq!(i, u8::conditional_select(&i, &j, 0.into()));
+                assert_eq!(j, u8::conditional_select(&i, &j, 1.into()));
+            }
+        }
+    }
+
+    #[test]
+    fn conditional_swap_u8() {
+        for i in 0..=::std::u8::MAX {
+            for j in 0..=::std::u8::MAX {
+                let mut i_copy = i;
+                let mut j_copy = j;
+
+                i_copy.conditional_swap(&mut j_copy, 0.into());
+                assert_eq!((i, j), (i_copy, j_copy));
+
+                i_copy.conditional_swap(&mut j_copy, 1.into());
+                assert_eq!((i, j), (j_copy, i_copy));
+            }
+        }
+    }
+
+    #[test]
+    fn conditional_assign_u8() {
+        for i in 0..=::std::u8::MAX {
+            for j in 0..=::std::u8::MAX {
+                let mut i_copy = i;
+
+                i_copy.conditional_assign(&j, 0.into());
+                assert_eq!(i_copy, i);
+
+                i_copy.conditional_assign(&j, 1.into());
+                assert_eq!(i_copy, j);
+            }
+        }
+    }
+
+    #[test]
+    fn conditional_select_u16() {
+        for i in 0..=::std::u16::MAX {
+            for j in 0..=::std::u16::MAX {
+                assert_eq!(i, u16::conditional_select(&i, &j, 0.into()));
+                assert_eq!(j, u16::conditional_select(&i, &j, 1.into()));
+            }
+        }
+    }
+
+    #[test]
+    fn conditional_swap_u16() {
+        for i in 0..=::std::u16::MAX {
+            for j in 0..=::std::u16::MAX {
+                let mut i_copy = i;
+                let mut j_copy = j;
+
+                i_copy.conditional_swap(&mut j_copy, 0.into());
+                assert_eq!((i, j), (i_copy, j_copy));
+
+                i_copy.conditional_swap(&mut j_copy, 1.into());
+                assert_eq!((i, j), (j_copy, i_copy));
+            }
+        }
+    }
+
+    #[test]
+    fn conditional_assign_u16() {
+        for i in 0..=::std::u16::MAX {
+            for j in 0..=::std::u16::MAX {
+                let mut i_copy = i;
+
+                i_copy.conditional_assign(&j, 0.into());
+                assert_eq!(i_copy, i);
+
+                i_copy.conditional_assign(&j, 1.into());
+                assert_eq!(i_copy, j);
+            }
+        }
+    }
+
+    #[test]
     fn conditional_assign_i32() {
         let mut a: i32 = 5;
         let b: i32 = 13;
@@ -592,7 +673,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "generic-impls")]
     fn conditional_assign_i64() {
         let mut c: i64 = 2343249123;
         let d: i64 = 8723884895;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,8 +404,8 @@ pub trait ConditionallyAssignable {
     /// # extern crate subtle;
     /// use subtle::ConditionallyAssignable;
     /// #
-    /// # #[cfg(features = "generic-impls")]
-    /// # fn do_test() {
+    /// # #[cfg(feature = "generic-impls")]
+    /// # fn main() {
     /// let mut x: u8 = 13;
     /// let y:     u8 = 42;
     ///
@@ -414,7 +414,7 @@ pub trait ConditionallyAssignable {
     /// x.conditional_assign(&y, 1.into());
     /// assert_eq!(x, 42);
     /// # }
-    /// # #[cfg(not(features = "generic-impls"))]
+    /// # #[cfg(not(feature = "generic-impls"))]
     /// # fn main () { }
     /// ```
     ///


### PR DESCRIPTION
Hi,

I've implemented `ConditionalSelect` for tuples of length 12, and `ConditionalSwap` and `ConditionalAssign` for slices. I've also added some tests to verify that the functions work as intended. Having these impls would be useful for a project I'm working on.

I have some questions that probably should be addressed before this is merged:

- [ ]  I've only implemented `ConditionalSelect` for tuples. Should I also impl the other traits unconditionally? (The `generic-impls` feature provides conditional impls if the elements of the tuple are `Copy`.)
- [ ]  Should I implement `ConditionalNegate` for slices?
- [ ]  Currently the impls of `ConditionalAssign` and `ConditionalSelect` panic in `debug` mode if the two slices are of unequal length, but in `release` mode they just modify the common locations of both slices. Is this reasonable behaviour?
- [ ]  Is there a way to verify that an implementation is actually constant time?  (I'm currently copy-pasting the code into godbolt and manually inspecting the results, but this is tedious and not-automizable.)