### PR TITLE
Collapse into a single ConditionallySwappable with provided methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subtle"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
            "Henry de Valence <hdevalence@hdevalence.ca>"]
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ enable it with no changes to the external interface).
 
 ```toml
 [dependencies.subtle]
-version = "1"
+version = "2"
 features = ["nightly"]
 ```
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -57,6 +57,21 @@ macro_rules! generate_integer_conditional_select_tests {
 
         assert_eq!(<$t>::conditional_select(&x, &y, 0.into()), 0);
         assert_eq!(<$t>::conditional_select(&x, &y, 1.into()), y);
+
+        let mut z = x;
+        let mut w = y;
+
+        <$t>::conditional_swap(&mut z, &mut w, 0.into());
+        assert_eq!(z, x);
+        assert_eq!(w, y);
+        <$t>::conditional_swap(&mut z, &mut w, 1.into());
+        assert_eq!(z, y);
+        assert_eq!(w, x);
+
+        z.conditional_assign(&x, 1.into());
+        w.conditional_assign(&y, 0.into());
+        assert_eq!(z, x);
+        assert_eq!(w, x);
     )*)
 }
 


### PR DESCRIPTION
Instead of having multiple traits with dependency relations, just have one
trait that has provided methods.  This allows maximum flexibility for the
implementor.