### PR TITLE
Introduce `Maybe` optional type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,12 +477,16 @@ where
 
 /// The `CtOption<T>` type represents an optional value similar to the
 /// [`Option<T>`](core::option::Option) type but is intended for
-/// use in constant time APIs. Any given `CtOption<T>` is either
-/// `Some` or `None`, but unlike `Option<T>` these variants are
-/// not exposed. The `is_some()` method is used to determine if the
-/// value is `Some`, and `unwrap_or`/`unwrap_or_else` methods are
+/// use in constant time APIs.
+///
+/// Any given `CtOption<T>` is either `Some` or `None`, but unlike
+/// `Option<T>` these variants are not exposed. The
+/// [`is_some()`](CtOption::is_some) method is used to determine if
+/// the value is `Some`, and [`unwrap_or()`](CtOption::unwrap_or) and
+/// [`unwrap_or_else()`](CtOption::unwrap_or_else) methods are
 /// provided to access the underlying value. The value can also be
-/// obtained with `unwrap()` but this will panic if it is None.
+/// obtained with [`unwrap()`](CtOption::unwrap) but this will panic
+/// if it is `None`.
 ///
 /// Functions that are intended to be constant time may not produce
 /// valid results for all inputs, such as square root and inversion

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,10 +139,7 @@ impl Not for Choice {
 /// than its type.
 ///
 /// Uses inline asm when available, otherwise it's a no-op.
-#[cfg(all(
-    feature = "nightly",
-    not(any(target_arch = "asmjs", target_arch = "wasm32"))
-))]
+#[cfg(all(feature = "nightly", not(any(target_arch = "asmjs", target_arch = "wasm32"))))]
 fn black_box(input: u8) -> u8 {
     debug_assert!(input == 0u8 || input == 1u8);
 
@@ -153,11 +150,7 @@ fn black_box(input: u8) -> u8 {
 
     input
 }
-#[cfg(any(
-    target_arch = "asmjs",
-    target_arch = "wasm32",
-    not(feature = "nightly")
-))]
+#[cfg(any(target_arch = "asmjs", target_arch = "wasm32", not(feature = "nightly")))]
 #[inline(never)]
 fn black_box(input: u8) -> u8 {
     debug_assert!(input == 0u8 || input == 1u8);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,6 +522,7 @@ impl<T> Maybe<T> {
         self.is_some
     }
 
+    /// Returns a true `Choice` if this value is `None`.
     #[inline]
     pub fn is_none(&self) -> Choice {
         !self.is_some

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,9 +480,9 @@ where
 /// use in constant time APIs. Any given `Maybe<T>` is either
 /// `Some` or `None`, but unlike `Option<T>` these variants are
 /// not exposed. The `is_some()` method is used to determine if the
-/// value is `Some`, and the `unwrap()` method is used to extract
-/// the underlying `Some` value (and will panic if the value is
-/// `None`).
+/// value is `Some`, and `unwrap_or`/`unwrap_or_else` methods are
+/// provided to access the underlying value. The value can also be
+/// obtained with `unwrap()` but this will panic if it is None.
 ///
 /// Functions that are intended to be constant time may not produce
 /// valid results for all inputs, such as square root and inversion
@@ -514,6 +514,25 @@ impl<T> Maybe<T> {
         assert_eq!(self.is_some.unwrap_u8(), 1);
 
         self.value
+    }
+
+    /// This returns the underlying value if it is `Some`
+    /// or the provided value otherwise.
+    #[inline]
+    pub fn unwrap_or(self, def: T) -> T
+        where T: ConditionallySelectable
+    {
+        T::conditional_select(&def, &self.value, self.is_some)
+    }
+
+    /// This returns the underlying value if it is `Some`
+    /// or the value produced by the provided closure otherwise.
+    #[inline]
+    pub fn unwrap_or_else<F>(self, f: F) -> T
+        where T: ConditionallySelectable,
+              F: FnOnce() -> T
+    {
+        T::conditional_select(&f(), &self.value, self.is_some)
     }
 
     /// Returns a true `Choice` if this value is `Some`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,6 +537,6 @@ impl<T: ConstantTimeEq> ConstantTimeEq for Maybe<T> {
         let a = self.is_some();
         let b = rhs.is_some();
 
-        (self.is_some() & rhs.is_some() & self.value.ct_eq(&rhs.value)) | (!a & !b)
+        (a & b & self.value.ct_eq(&rhs.value)) | (!a & !b)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,7 +504,7 @@ impl<T> CtOption<T> {
     /// exposed.
     #[inline]
     pub fn new(value: T, is_some: Choice) -> CtOption<T> {
-        CtOption { value, is_some }
+        CtOption { value: value, is_some: is_some }
     }
 
     /// This returns the underlying value but panics if it

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -154,6 +154,14 @@ fn test_maybe() {
     // Test equality of None with different
     // dummy value
     assert!(bool::from(c.ct_eq(&d)));
+
+    // Test unwrap_or
+    assert_eq!(Maybe::new(1, Choice::from(1)).unwrap_or(2), 1);
+    assert_eq!(Maybe::new(1, Choice::from(0)).unwrap_or(2), 2);
+
+    // Test unwrap_or_else
+    assert_eq!(Maybe::new(1, Choice::from(1)).unwrap_or_else(|| 2), 1);
+    assert_eq!(Maybe::new(1, Choice::from(0)).unwrap_or_else(|| 2), 2);
 }
 
 #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -162,6 +162,72 @@ fn test_maybe() {
     // Test unwrap_or_else
     assert_eq!(Maybe::new(1, Choice::from(1)).unwrap_or_else(|| 2), 1);
     assert_eq!(Maybe::new(1, Choice::from(0)).unwrap_or_else(|| 2), 2);
+
+    // Test map
+    assert_eq!(
+        Maybe::new(1, Choice::from(1))
+            .map(|v| {
+                assert_eq!(v, 1);
+                2
+            })
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        Maybe::new(1, Choice::from(0))
+            .map(|_| 2)
+            .is_none()
+            .unwrap_u8(),
+        1
+    );
+
+    // Test and_then
+    assert_eq!(
+        Maybe::new(1, Choice::from(1))
+            .and_then(|v| {
+                assert_eq!(v, 1);
+                Maybe::new(2, Choice::from(0))
+            })
+            .is_none()
+            .unwrap_u8(),
+        1
+    );
+    assert_eq!(
+        Maybe::new(1, Choice::from(1))
+            .and_then(|v| {
+                assert_eq!(v, 1);
+                Maybe::new(2, Choice::from(1))
+            })
+            .unwrap(),
+        2
+    );
+
+    assert_eq!(
+        Maybe::new(1, Choice::from(0))
+            .and_then(|_| Maybe::new(2, Choice::from(0)))
+            .is_none()
+            .unwrap_u8(),
+        1
+    );
+    assert_eq!(
+        Maybe::new(1, Choice::from(0))
+            .and_then(|_| Maybe::new(2, Choice::from(1)))
+            .is_none()
+            .unwrap_u8(),
+        1
+    );
+
+    // Test (in)equality
+    assert!(Maybe::new(1, Choice::from(0)).ct_eq(&Maybe::new(1, Choice::from(1))).unwrap_u8() == 0);
+    assert!(Maybe::new(1, Choice::from(1)).ct_eq(&Maybe::new(1, Choice::from(0))).unwrap_u8() == 0);
+    assert!(Maybe::new(1, Choice::from(0)).ct_eq(&Maybe::new(2, Choice::from(1))).unwrap_u8() == 0);
+    assert!(Maybe::new(1, Choice::from(1)).ct_eq(&Maybe::new(2, Choice::from(0))).unwrap_u8() == 0);
+    assert!(Maybe::new(1, Choice::from(0)).ct_eq(&Maybe::new(1, Choice::from(0))).unwrap_u8() == 1);
+    assert!(Maybe::new(1, Choice::from(0)).ct_eq(&Maybe::new(2, Choice::from(0))).unwrap_u8() == 1);
+    assert!(Maybe::new(1, Choice::from(1)).ct_eq(&Maybe::new(2, Choice::from(1))).unwrap_u8() == 0);
+    assert!(Maybe::new(1, Choice::from(1)).ct_eq(&Maybe::new(2, Choice::from(1))).unwrap_u8() == 0);
+    assert!(Maybe::new(1, Choice::from(1)).ct_eq(&Maybe::new(1, Choice::from(1))).unwrap_u8() == 1);
+    assert!(Maybe::new(1, Choice::from(1)).ct_eq(&Maybe::new(1, Choice::from(1))).unwrap_u8() == 1);
 }
 
 #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -123,3 +123,43 @@ fn choice_into_bool() {
 
     assert!(!choice_false);
 }
+
+#[test]
+fn test_maybe() {
+    let a = Maybe::new(10, Choice::from(1));
+    let b = Maybe::new(9, Choice::from(1));
+    let c = Maybe::new(10, Choice::from(0));
+    let d = Maybe::new(9, Choice::from(0));
+
+    // Test is_some / is_none
+    assert!(bool::from(a.is_some()));
+    assert!(bool::from(!a.is_none()));
+    assert!(bool::from(b.is_some()));
+    assert!(bool::from(!b.is_none()));
+    assert!(bool::from(!c.is_some()));
+    assert!(bool::from(c.is_none()));
+    assert!(bool::from(!d.is_some()));
+    assert!(bool::from(d.is_none()));
+
+    // Test unwrap for Some
+    assert_eq!(a.unwrap(), 10);
+    assert_eq!(b.unwrap(), 9);
+
+    // Test equality
+    assert!(bool::from(a.ct_eq(&a)));
+    assert!(bool::from(!a.ct_eq(&b)));
+    assert!(bool::from(!a.ct_eq(&c)));
+    assert!(bool::from(!a.ct_eq(&d)));
+
+    // Test equality of None with different
+    // dummy value
+    assert!(bool::from(c.ct_eq(&d)));
+}
+
+#[test]
+#[should_panic]
+fn unwrap_none_maybe() {
+    // This test might fail (in release mode?) if the
+    // compiler decides to optimize it away.
+    Maybe::new(10, Choice::from(0)).unwrap();
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -125,11 +125,11 @@ fn choice_into_bool() {
 }
 
 #[test]
-fn test_maybe() {
-    let a = Maybe::new(10, Choice::from(1));
-    let b = Maybe::new(9, Choice::from(1));
-    let c = Maybe::new(10, Choice::from(0));
-    let d = Maybe::new(9, Choice::from(0));
+fn test_ctoption() {
+    let a = CtOption::new(10, Choice::from(1));
+    let b = CtOption::new(9, Choice::from(1));
+    let c = CtOption::new(10, Choice::from(0));
+    let d = CtOption::new(9, Choice::from(0));
 
     // Test is_some / is_none
     assert!(bool::from(a.is_some()));
@@ -156,16 +156,16 @@ fn test_maybe() {
     assert!(bool::from(c.ct_eq(&d)));
 
     // Test unwrap_or
-    assert_eq!(Maybe::new(1, Choice::from(1)).unwrap_or(2), 1);
-    assert_eq!(Maybe::new(1, Choice::from(0)).unwrap_or(2), 2);
+    assert_eq!(CtOption::new(1, Choice::from(1)).unwrap_or(2), 1);
+    assert_eq!(CtOption::new(1, Choice::from(0)).unwrap_or(2), 2);
 
     // Test unwrap_or_else
-    assert_eq!(Maybe::new(1, Choice::from(1)).unwrap_or_else(|| 2), 1);
-    assert_eq!(Maybe::new(1, Choice::from(0)).unwrap_or_else(|| 2), 2);
+    assert_eq!(CtOption::new(1, Choice::from(1)).unwrap_or_else(|| 2), 1);
+    assert_eq!(CtOption::new(1, Choice::from(0)).unwrap_or_else(|| 2), 2);
 
     // Test map
     assert_eq!(
-        Maybe::new(1, Choice::from(1))
+        CtOption::new(1, Choice::from(1))
             .map(|v| {
                 assert_eq!(v, 1);
                 2
@@ -174,7 +174,7 @@ fn test_maybe() {
         2
     );
     assert_eq!(
-        Maybe::new(1, Choice::from(0))
+        CtOption::new(1, Choice::from(0))
             .map(|_| 2)
             .is_none()
             .unwrap_u8(),
@@ -183,57 +183,57 @@ fn test_maybe() {
 
     // Test and_then
     assert_eq!(
-        Maybe::new(1, Choice::from(1))
+        CtOption::new(1, Choice::from(1))
             .and_then(|v| {
                 assert_eq!(v, 1);
-                Maybe::new(2, Choice::from(0))
+                CtOption::new(2, Choice::from(0))
             })
             .is_none()
             .unwrap_u8(),
         1
     );
     assert_eq!(
-        Maybe::new(1, Choice::from(1))
+        CtOption::new(1, Choice::from(1))
             .and_then(|v| {
                 assert_eq!(v, 1);
-                Maybe::new(2, Choice::from(1))
+                CtOption::new(2, Choice::from(1))
             })
             .unwrap(),
         2
     );
 
     assert_eq!(
-        Maybe::new(1, Choice::from(0))
-            .and_then(|_| Maybe::new(2, Choice::from(0)))
+        CtOption::new(1, Choice::from(0))
+            .and_then(|_| CtOption::new(2, Choice::from(0)))
             .is_none()
             .unwrap_u8(),
         1
     );
     assert_eq!(
-        Maybe::new(1, Choice::from(0))
-            .and_then(|_| Maybe::new(2, Choice::from(1)))
+        CtOption::new(1, Choice::from(0))
+            .and_then(|_| CtOption::new(2, Choice::from(1)))
             .is_none()
             .unwrap_u8(),
         1
     );
 
     // Test (in)equality
-    assert!(Maybe::new(1, Choice::from(0)).ct_eq(&Maybe::new(1, Choice::from(1))).unwrap_u8() == 0);
-    assert!(Maybe::new(1, Choice::from(1)).ct_eq(&Maybe::new(1, Choice::from(0))).unwrap_u8() == 0);
-    assert!(Maybe::new(1, Choice::from(0)).ct_eq(&Maybe::new(2, Choice::from(1))).unwrap_u8() == 0);
-    assert!(Maybe::new(1, Choice::from(1)).ct_eq(&Maybe::new(2, Choice::from(0))).unwrap_u8() == 0);
-    assert!(Maybe::new(1, Choice::from(0)).ct_eq(&Maybe::new(1, Choice::from(0))).unwrap_u8() == 1);
-    assert!(Maybe::new(1, Choice::from(0)).ct_eq(&Maybe::new(2, Choice::from(0))).unwrap_u8() == 1);
-    assert!(Maybe::new(1, Choice::from(1)).ct_eq(&Maybe::new(2, Choice::from(1))).unwrap_u8() == 0);
-    assert!(Maybe::new(1, Choice::from(1)).ct_eq(&Maybe::new(2, Choice::from(1))).unwrap_u8() == 0);
-    assert!(Maybe::new(1, Choice::from(1)).ct_eq(&Maybe::new(1, Choice::from(1))).unwrap_u8() == 1);
-    assert!(Maybe::new(1, Choice::from(1)).ct_eq(&Maybe::new(1, Choice::from(1))).unwrap_u8() == 1);
+    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(1, Choice::from(1))).unwrap_u8() == 0);
+    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(1, Choice::from(0))).unwrap_u8() == 0);
+    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(2, Choice::from(1))).unwrap_u8() == 0);
+    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(2, Choice::from(0))).unwrap_u8() == 0);
+    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(1, Choice::from(0))).unwrap_u8() == 1);
+    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(2, Choice::from(0))).unwrap_u8() == 1);
+    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(2, Choice::from(1))).unwrap_u8() == 0);
+    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(2, Choice::from(1))).unwrap_u8() == 0);
+    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(1, Choice::from(1))).unwrap_u8() == 1);
+    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(1, Choice::from(1))).unwrap_u8() == 1);
 }
 
 #[test]
 #[should_panic]
-fn unwrap_none_maybe() {
+fn unwrap_none_ctoption() {
     // This test might fail (in release mode?) if the
     // compiler decides to optimize it away.
-    Maybe::new(10, Choice::from(0)).unwrap();
+    CtOption::new(10, Choice::from(0)).unwrap();
 }


### PR DESCRIPTION
See #39.

The reason this came about is because we're implementing algorithms for field arithmetic in one of our crates and the current practice (as seen in `curve25519-dalek` for example) of

1. If you call `invert()` it returns zero for a zero input, when it should actually fail.
2. If you call inverse square root, it will return a value and a `Choice` indicating whether it's correct or not; the caller could accidentally forget.

is error prone. Given this new `Maybe` abstraction

1. Inversion can now return a `Maybe<T>` and if the caller is sure that the inputs are never zero, they can `unwrap()` themselves to make it explicit.
2. (Inverse) square root can return a `Maybe<T>` and the caller can choose how to deal with it. If they want to deal with the case in constant time, they can.

The API in this PR is really simple and could probably be extended to support e.g. constant time mapping over the underlying value, but I want to avoid blocking this feature on the inevitable questions of how such APIs should behave. What's implemented in this PR should be sufficient for all of the users of `subtle` I know about, and we can extend it later without breaking backwards compatibility.

The only question is whether or not the name `Maybe` is good.