### PR TITLE
Optimize black_box

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,8 @@ impl Not for Choice {
 fn black_box(mut input: u8) -> u8 {
     debug_assert!((input == 0u8) | (input == 1u8));
 
-    unsafe { asm!("" : "=r"(input) : "0"(input) }
+    // Move value through assembler, which is opaque to the compiler, even though we don't do anything.
+    unsafe { asm!("" : "=r"(input) : "0"(input) ) }
 
     input
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,13 +142,11 @@ impl Not for Choice {
 ///
 /// Uses inline asm when available, otherwise it's a no-op.
 #[cfg(all(feature = "nightly", not(any(target_arch = "asmjs", target_arch = "wasm32"))))]
-fn black_box(input: u8) -> u8 {
+#[inline(always)]
+fn black_box(mut input: u8) -> u8 {
     debug_assert!((input == 0u8) | (input == 1u8));
 
-    // Pretend to access a register containing the input.  We "volatile" here
-    // because some optimisers treat assembly templates without output operands
-    // as "volatile" while others do not.
-    unsafe { asm!("" :: "r"(&input) :: "volatile") }
+    unsafe { asm!("" : "=r"(input) : "0"(input) }
 
     input
 }


### PR DESCRIPTION
The previous assembly code required the compiler to move the value into memory to be able to pass the pointer into assembly. Often this also resulted in the function not being inlined. I believe this code is equivalent in terms of black box behavior but allows for much better codegen in the case where `input` is already in a register.