### PR TITLE
Harden stable implementation of black_box

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,6 @@ To prevent the latter possibility, when using the `nightly` feature
 from the optimizer, by passing it through an inline assembly block.  For more
 information, see the _About_ section below.
 
-When not using the `nightly` feature, there is no protection against b).  This
-is unfortunate, but is at least no worse than C code, and has the advantange
-that if a suitable black box is stabilized, we will be able to transparently
-enable it with no changes to the external interface).
-
 ```toml
 [dependencies.subtle]
 version = "2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,8 +161,7 @@ fn black_box(input: u8) -> u8 {
     //
     // Note: Rust's notion of "volatile" is subject to change over time. While this code may break
     // in a non-destructive way in the future, it is better than doing nothing.
-    //
-    debug_assert!(!core::mem::needs_drop::<u8>());
+
     unsafe {
         // Optimization barrier
         //
@@ -170,7 +169,7 @@ fn black_box(input: u8) -> u8 {
         //   - &input is not NULL;
         //   - size of input is not zero;
         //   - u8 is neither Sync, nor Send;
-        //   - u8 is Copy (also asserted just before), so input is always live;
+        //   - u8 is Copy, so input is always live;
         //   - u8 type is always properly aligned.
         core::ptr::read_volatile(&input as *const u8)
     }


### PR DESCRIPTION
This PR improves the implementation of `black_box`, using the fact that the semantics of `volatile` are pretty well defined. With this change, you could probably even omit `#[inline(never)]`, and then it may even be more efficient (I didn't benchmark).

> `// Bailing out, hopefully the compiler doesn't use the fact that ``input`` is 0 or 1.`

This patch also defines this case. ^

Example codegen: https://godbolt.org/z/3xYX1U