### PR TITLE
travis: Fix no-std build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,10 @@ matrix:
       env: NAME="MSRV test"
       script: cargo test --no-default-features --features std
     # Test if crate can be truly built without std
-    # Disabled because this tooling started to error, feel free to fix it
-    #- rust: nightly
-    #  env: TARGET=thumbv7em-none-eabi
-    #  script: xargo build --no-default-features --target $TARGET
-    #  install:
-    #    - cargo install xargo || true
-    #    - rustup target install armv7-unknown-linux-gnueabihf
-    #    - rustup component add rust-src
+    - env: TARGET=thumbv7em-none-eabi
+      script: cargo build --no-default-features --target $TARGET
+      install:
+        - rustup target add $TARGET
 
 script:
   - cargo test && cargo test --no-default-features &&


### PR DESCRIPTION
https://github.com/dalek-cryptography/subtle/blob/f6028bca3ffa81bb7202dd409ba69047099d2510/.travis.yml#L18-L19

This PR fixes the `no_std` build, by updating the travis config to modern rust-embedded guidelines. I chose the `thumbv7em-none-eabi` target, because I feel that these devices (in particular the ARM Cortex M4) are pretty popular in the crypto-engineering community.