### PR TITLE
Haybale tests for constant-time violations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,7 @@ default = ["std", "i128"]
 std = []
 i128 = []
 nightly = []
+
+[dev-dependencies]
+llvm-ir = "^0.5"
+pitchfork = { package = "haybale-pitchfork", version = "^0.2" }

--- a/tests/haybale.rs
+++ b/tests/haybale.rs
@@ -1,0 +1,67 @@
+extern crate llvm_ir;
+extern crate pitchfork;
+extern crate subtle;
+
+use pitchfork::{
+    AbstractData,
+    Config,
+    PitchforkConfig,
+    Project,
+    StructDescriptions,
+    check_for_ct_violation,
+};
+
+use subtle::ConstantTimeEq;
+
+//  Haybale[-pitchfork] require llvm-sys (LLVM Rust bindings) and boolector
+//    llvm-sys and boolector need to be installed as shared libraries prior
+//    to compiling this test.
+//
+//  Generate LLVM bitcode:
+//
+//      CARGO_INCREMENTAL="" cargo rustc -- -g --emit llvm-bc
+//
+//  Run test:
+//
+//      cargo test --test haybale
+#[test]
+fn test_ct_haybale() {
+    let a: u8 = 0x42;
+    let b: u8 = 0x43;
+
+    // Use ConstantTimeEq trait to generate LLVM bitcode
+    let _ = a.ct_eq(&a.clone());
+    let _ = a.ct_eq(&b);
+
+    let c: [u8; 3] = [0x40, 0x41, 0x42];
+    let d: [u8; 3] = [0x40, 0x43, 0x41];
+
+    let _ = c.ct_eq(&c.clone());
+    let _ = c.ct_eq(&d);
+
+    // Path to generated bitcode
+    let mut bc_path = std::env::current_exe().unwrap();
+    bc_path.pop();
+
+    let project = Project::from_bc_dir(&bc_path, "bc").unwrap();
+
+    // Get all mangled function names for ConstantTimeEq implementations
+    let ct_func_names = project
+        .all_functions()
+        .filter(|x| x.0.name.contains("ct_eq"))
+        .collect::<Vec<(&llvm_ir::Function, &llvm_ir::module::Module)>>();
+
+    // Test each function for constant-time violations
+    for func in ct_func_names {
+        let result = check_for_ct_violation(&func.0.name,
+                                            &project,
+                                            Some(vec![AbstractData::pub_pointer_to(AbstractData::secret()), AbstractData::pub_pointer_to(AbstractData::secret())]),
+                                            &StructDescriptions::default(),
+                                            Config::default(),
+                                            &PitchforkConfig::default());
+
+        if result.path_results.len() != 0 {
+            panic!("Constant-time result:\n\n{}", &result);
+        }
+    }
+}


### PR DESCRIPTION
Integration tests using the [haybale](https://github.com/PLSysSec/haybale) SMT solver
and [haybale-pitchfork](https://github.com/PLSysSec/haybale-pitchfork) crates for discovering constant-time violations.

The current test reports a violation originating from `std::ops::BitXor`
being used for bitwise-XOR comparison.

The result may be a false-positive, so please disregard if it is.

If it is a valid result, one solution may be to write a new trait
for constant-time bitwise-XOR (e.g. `subtle::CtBitXor`).