### PR TITLE
Update lib.rs because of change in nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ fn black_box(mut input: u8) -> u8 {
     debug_assert!((input == 0u8) | (input == 1u8));
 
     // Move value through assembler, which is opaque to the compiler, even though we don't do anything.
-    unsafe { asm!("" : "=r"(input) : "0"(input) ) }
+    unsafe { llvm_asm!("" : "=r"(input) : "0"(input) ) }
 
     input
 }


### PR DESCRIPTION
Building with latest rust nightlies are throwing this error.
```
error: legacy asm! syntax is no longer supported
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/subtle-2.2.2/src/lib.rs:150:14
    |
150 |     unsafe { asm!("" : "=r"(input) : "0"(input) ) }
    |              ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |              |
    |              help: replace with: `llvm_asm!
```
So I did the change.  ¯\_(ツ)_/¯