### PR TITLE
Remove inline assembly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,33 @@ It consists of a `Choice` type, and a collection of traits using `Choice`
 instead of `bool` which are intended to execute in constant-time.  The `Choice`
 type is a wrapper around a `u8` that holds a `0` or `1`.
 
+```toml
+subtle = "2.2"
+```
+
 This crate represents a “best-effort” attempt, since side-channels
 are ultimately a property of a deployed cryptographic system
 including the hardware it runs on, not just of software.
 
 The traits are implemented using bitwise operations, and should execute in
-constant time provided that a) the bitwise operations are constant-time and b)
-the operations are not optimized into a branch.
+constant time provided that a) the bitwise operations are constant-time and
+b) the bitwise operations are not recognized as a conditional assignment and
+optimized back into a branch.
 
-To prevent the latter possibility, the crate attempts to hide the value of a
-`Choice`'s inner `u8` from the optimizer, by passing it through either an
-inline assembly block or a volatile read.  For more information, see the
-_About_ section below.
-
-```toml
-[dependencies.subtle]
-version = "2.2"
-```
+For a compiler to recognize that bitwise operations represent a conditional
+assignment, it needs to know that the value used to generate the bitmasks is
+really a boolean `i1` rather than an `i8` byte value. In an attempt to
+prevent this refinement, the crate tries to hide the value of a `Choice`'s
+inner `u8` by passing it through a volatile read. For more information, see
+the _About_ section below.
 
 Versions prior to `2.2` recommended use of the `nightly` feature to enable an
 optimization barrier; this is not required in versions `2.2` and above.
+
+Note: the `subtle` crate contains `debug_assert`s to check invariants during
+debug builds. These invariant checks involve secret-dependent branches, and
+are not present when compiled in release mode. This crate is intended to be
+used in release mode.
 
 ## Documentation
 


### PR DESCRIPTION
This is broken on nightly, since asm has been changed to llvm_asm. But rather
than fixing it, we can simply drop it, because we now have an optimization
barrier that works on stable Rust with no platform dependencies.

Also, update the README and docs to reflect this change.

Closes #70 #67 