### PR TITLE
Implement `From<CtOption<T>> for Option<T>

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       env: NAME="nightly feature"
       script: cargo test --features nightly
     # Test MSRV
-    - rust: 1.13.0
+    - rust: 1.41.0
       env: NAME="MSRV test"
       script: cargo test --no-default-features --features std
     # Test if crate can be truly built without std

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ used in release mode.
 
 Documentation is available [here][docs].
 
+## Minimum Supported Rust Version
+
+Rust **1.41** or higher.
+
+Minimum supported Rust version can be changed in the future, but it will be done with a minor version bump.
+
 ## About
 
 This library aims to be the Rust equivalent of Go’s `crypto/subtle` module.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,6 +500,7 @@ pub struct CtOption<T> {
     is_some: Choice,
 }
 
+#[cfg(feature = "std")]
 impl<T> From<CtOption<T>> for Option<T> {
     /// Convert the `CtOption<T>` wrapper into an `Option<T>`, depending on whether
     /// the underlying `is_some` `Choice` was a `0` or a `1` once unwrapped.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 extern crate std;
 
 use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Neg, Not};
-use std::option::Option;
+use core::option::Option;
 
 /// The `Choice` struct represents a choice for use in conditional assignment.
 ///
@@ -500,7 +500,6 @@ pub struct CtOption<T> {
     is_some: Choice,
 }
 
-#[cfg(feature = "std")]
 impl<T> From<CtOption<T>> for Option<T> {
     /// Convert the `CtOption<T>` wrapper into an `Option<T>`, depending on whether
     /// the underlying `is_some` `Choice` was a `0` or a `1` once unwrapped.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,22 +23,23 @@
 extern crate std;
 
 use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Neg, Not};
+use std::option::Option;
 
 /// The `Choice` struct represents a choice for use in conditional assignment.
-/// 
+///
 /// It is a wrapper around a `u8`, which should have the value either `1` (true)
 /// or `0` (false).
-/// 
+///
 /// The conversion from `u8` to `Choice` passes the value through an optimization
 /// barrier, as a best-effort attempt to prevent the compiler from inferring that
 /// the `Choice` value is a boolean. This strategy is based on Tim Maclean's
 /// [work on `rust-timing-shield`][rust-timing-shield], which attempts to provide
 /// a more comprehensive approach for preventing software side-channels in Rust
 /// code.
-/// 
+///
 /// The `Choice` struct implements operators for AND, OR, XOR, and NOT, to allow
 /// combining `Choice` values. These operations do not short-circuit.
-/// 
+///
 /// [rust-timing-shield]:
 /// https://www.chosenplaintext.ca/open-source/rust-timing-shield/security
 #[derive(Copy, Clone, Debug)]
@@ -136,11 +137,11 @@ impl Not for Choice {
 
 /// This function is a best-effort attempt to prevent the compiler from knowing
 /// anything about the value of the returned `u8`, other than its type.
-/// 
+///
 /// Because we want to support stable Rust, we don't have access to inline
 /// assembly or test::black_box, so we use the fact that volatile values will
 /// never be elided to register values.
-/// 
+///
 /// Note: Rust's notion of "volatile" is subject to change over time. While this
 /// code may break in a non-destructive way in the future, “constant-time” code
 /// is a continually moving target, and this is better than doing nothing.
@@ -499,6 +500,25 @@ pub struct CtOption<T> {
     is_some: Choice,
 }
 
+impl<T> From<CtOption<T>> for Option<T> {
+    /// Convert the `CtOption<T>` wrapper into an `Option<T>`, depending on whether
+    /// the underlying `is_some` `Choice` was a `0` or a `1` once unwrapped.
+    ///
+    /// # Note
+    ///
+    /// This function exists to avoid ending up with ugly, verbose and/or bad handled
+    /// conversions from the `CtOption<T>` wraps to an `Option<T>` or `Result<T, E>`.
+    /// This implementation doesn't intend to be constant-time nor try to protect the
+    /// leakage of the `T` since the `Option<T>` will do it anyways.
+    fn from(source: CtOption<T>) -> Option<T> {
+        if source.is_some().unwrap_u8() == 1u8 {
+            Option::Some(source.value)
+        } else {
+            None
+        }
+    }
+}
+
 impl<T> CtOption<T> {
     /// This method is used to construct a new `CtOption<T>` and takes
     /// a value of type `T`, and a `Choice` that determines whether
@@ -507,7 +527,10 @@ impl<T> CtOption<T> {
     /// exposed.
     #[inline]
     pub fn new(value: T, is_some: Choice) -> CtOption<T> {
-        CtOption { value: value, is_some: is_some }
+        CtOption {
+            value: value,
+            is_some: is_some,
+        }
     }
 
     /// This returns the underlying value but panics if it


### PR DESCRIPTION
As stated in #73 and #74 the `CtOption<T>` API is a bit
unflexible when you try to extract the value from the
`CtOption` or you want to convert the `CtOption<T>`
into an `Option<T>` or a `Result<T>`.

Therefore the conversion from `CtOption<T>` to `Option<T>`
has been implemented to avoid having situations like:
```rust
if ct_opt.is_some() {
     return ct_opt.unwrap()
} else {
    return Err(....)
}
```

### NOTE:
This impl is done to avoid ending up with unpractical, verbose and/or bad handled
conversions from the `CtOption<T>` wraps to an `Option<T>` or `Result<T, E>`.
This implementation doesn't intend to be constant-time nor try to protect the
leakage of the `T` since the `Option<T>` will do it anyways.

Closes #73
Closes #74

I wasn't sure about adding an `Unreleased` section on the `CHANGELOG.md` or just leave it to you so you can handle this however you want. In any case, if you need I can add whatever.

It also seems that `cargo fmt` was applied on some places. Maybe it would be nice to add a rustfmt.toml file or something similar in the future.

### EDIT
The code uploaded to solve #73 & #74 includes a feature that
was added to the Rust language in Rust_1.41.0 via RFC2451.

Therefore, the minimum version needed in order to allow the tests
pass for the MSRV testcase is the one mentioned avobe.

As suggested per @hdevalence, it might not be worth it to try to
support a +4yo version of Rust, so the .travis.yml has been changed
in order to update the version used to test the MSRV case to 1.41.0.