### PR TITLE
Impl ConstantTimeEq for Choice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,13 @@ impl<T: ConstantTimeEq> ConstantTimeEq for [T] {
     }
 }
 
+impl ConstantTimeEq for Choice {
+    #[inline]
+    fn ct_eq(&self, rhs: &Choice) -> Choice {
+        !(*self ^ *rhs)
+    }
+}
+
 /// Given the bit-width `$bit_width` and the corresponding primitive
 /// unsigned and signed types `$t_u` and `$t_i` respectively, generate
 /// an `ConstantTimeEq` implementation.

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -136,6 +136,14 @@ fn conditional_select_choice() {
 }
 
 #[test]
+fn choice_equal() {
+    assert!(Choice::from(0).ct_eq(&Choice::from(0)).unwrap_u8() == 1);
+    assert!(Choice::from(0).ct_eq(&Choice::from(1)).unwrap_u8() == 0);
+    assert!(Choice::from(1).ct_eq(&Choice::from(0)).unwrap_u8() == 0);
+    assert!(Choice::from(1).ct_eq(&Choice::from(1)).unwrap_u8() == 1);
+}
+
+#[test]
 fn test_ctoption() {
     let a = CtOption::new(10, Choice::from(1));
     let b = CtOption::new(9, Choice::from(1));


### PR DESCRIPTION
Uses XNOR on two `Choice` values to provide constant time equality comparisons.

I've seen this pattern a lot in code and thought it might be nice to wrap it up this way.