### PR TITLE
Add ConstantTime{Greater,Less}Than traits and impls for unsigned integers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ exclude = [
 [badges]
 travis-ci = { repository = "dalek-cryptography/subtle", branch = "master"}
 
+[dev-dependencies]
+rand = { version = "0.7" }
+
 [features]
 default = ["std", "i128"]
 std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -745,7 +745,45 @@ generate_unsigned_integer_greater_than!(u64, 64);
 #[cfg(feature = "i128")]
 generate_unsigned_integer_greater_than!(u128, 128);
 
+/// A type which can be compared in some manner and be determined to be less
+/// than another of the same type.
 pub trait ConstantTimeLessThan: ConstantTimeEq + ConstantTimeGreaterThan {
+    /// Determine whether `self < other`.
+    ///
+    /// The bitwise-NOT of the return value of this function should be usable to
+    /// determine if `self >= other`.
+    ///
+    /// A default implementation is provided and implemented for the unsigned
+    /// integer types.
+    ///
+    /// This function should execute in constant time.
+    ///
+    /// # Returns
+    ///
+    /// A `Choice` with a set bit if `self < other`, and with no set bits
+    /// otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate subtle;
+    /// use subtle::ConstantTimeLessThan;
+    ///
+    /// let x: u8 = 13;
+    /// let y: u8 = 42;
+    ///
+    /// let x_lt_y = x.ct_lt(&y);
+    ///
+    /// assert_eq!(x_lt_y.unwrap_u8(), 1);
+    ///
+    /// let y_lt_x = y.ct_lt(&x);
+    ///
+    /// assert_eq!(y_lt_x.unwrap_u8(), 0);
+    ///
+    /// let x_lt_x = x.ct_lt(&x);
+    ///
+    /// assert_eq!(x_lt_x.unwrap_u8(), 0);
+    /// ```
     #[inline]
     fn ct_lt(&self, other: &Self) -> Choice {
         !self.ct_gt(other) & !self.ct_eq(other)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,7 +670,7 @@ impl<T: ConstantTimeEq> ConstantTimeEq for CtOption<T> {
 
 /// A type which can be compared in some manner and be determined to be greater
 /// than another of the same type.
-pub trait ConstantTimeGreaterThan {
+pub trait ConstantTimeGreater {
     /// Determine whether `self > other`.
     ///
     /// The bitwise-NOT of the return value of this function should be usable to
@@ -687,7 +687,7 @@ pub trait ConstantTimeGreaterThan {
     ///
     /// ```
     /// # extern crate subtle;
-    /// use subtle::ConstantTimeGreaterThan;
+    /// use subtle::ConstantTimeGreater;
     ///
     /// let x: u8 = 13;
     /// let y: u8 = 42;
@@ -707,9 +707,9 @@ pub trait ConstantTimeGreaterThan {
     fn ct_gt(&self, other: &Self) -> Choice;
 }
 
-macro_rules! generate_unsigned_integer_greater_than {
+macro_rules! generate_unsigned_integer_greater {
     ($t_u: ty, $bit_width: expr) => {
-        impl ConstantTimeGreaterThan for $t_u {
+        impl ConstantTimeGreater for $t_u {
             /// Returns Choice::from(1) iff x > y, and Choice::from(0) iff x <= y.
             ///
             /// # Note
@@ -742,16 +742,16 @@ macro_rules! generate_unsigned_integer_greater_than {
     }
 }
 
-generate_unsigned_integer_greater_than!(u8, 8);
-generate_unsigned_integer_greater_than!(u16, 16);
-generate_unsigned_integer_greater_than!(u32, 32);
-generate_unsigned_integer_greater_than!(u64, 64);
+generate_unsigned_integer_greater!(u8, 8);
+generate_unsigned_integer_greater!(u16, 16);
+generate_unsigned_integer_greater!(u32, 32);
+generate_unsigned_integer_greater!(u64, 64);
 #[cfg(feature = "i128")]
-generate_unsigned_integer_greater_than!(u128, 128);
+generate_unsigned_integer_greater!(u128, 128);
 
 /// A type which can be compared in some manner and be determined to be less
 /// than another of the same type.
-pub trait ConstantTimeLessThan: ConstantTimeEq + ConstantTimeGreaterThan {
+pub trait ConstantTimeLess: ConstantTimeEq + ConstantTimeGreater {
     /// Determine whether `self < other`.
     ///
     /// The bitwise-NOT of the return value of this function should be usable to
@@ -771,7 +771,7 @@ pub trait ConstantTimeLessThan: ConstantTimeEq + ConstantTimeGreaterThan {
     ///
     /// ```
     /// # extern crate subtle;
-    /// use subtle::ConstantTimeLessThan;
+    /// use subtle::ConstantTimeLess;
     ///
     /// let x: u8 = 13;
     /// let y: u8 = 42;
@@ -794,9 +794,9 @@ pub trait ConstantTimeLessThan: ConstantTimeEq + ConstantTimeGreaterThan {
     }
 }
 
-impl ConstantTimeLessThan for u8 {}
-impl ConstantTimeLessThan for u16 {}
-impl ConstantTimeLessThan for u32 {}
-impl ConstantTimeLessThan for u64 {}
+impl ConstantTimeLess for u8 {}
+impl ConstantTimeLess for u16 {}
+impl ConstantTimeLess for u32 {}
+impl ConstantTimeLess for u64 {}
 #[cfg(feature = "i128")]
-impl ConstantTimeLessThan for u128 {}
+impl ConstantTimeLess for u128 {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -744,3 +744,17 @@ generate_unsigned_integer_greater_than!(u32, 32);
 generate_unsigned_integer_greater_than!(u64, 64);
 #[cfg(feature = "i128")]
 generate_unsigned_integer_greater_than!(u128, 128);
+
+pub trait ConstantTimeLessThan: ConstantTimeEq + ConstantTimeGreaterThan {
+    #[inline]
+    fn ct_lt(&self, other: &Self) -> Choice {
+        !self.ct_gt(other) & !self.ct_eq(other)
+    }
+}
+
+impl ConstantTimeLessThan for u8 {}
+impl ConstantTimeLessThan for u16 {}
+impl ConstantTimeLessThan for u32 {}
+impl ConstantTimeLessThan for u64 {}
+#[cfg(feature = "i128")]
+impl ConstantTimeLessThan for u128 {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -699,6 +699,10 @@ pub trait ConstantTimeGreaterThan {
     /// let y_gt_x = y.ct_gt(&x);
     ///
     /// assert_eq!(y_gt_x.unwrap_u8(), 1);
+    ///
+    /// let x_gt_x = x.ct_gt(&x);
+    ///
+    /// assert_eq!(x_gt_x.unwrap_u8(), 0);
     /// ```
     fn ct_gt(&self, other: &Self) -> Choice;
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,4 +1,8 @@
+extern crate rand;
 extern crate subtle;
+
+use rand::rngs::OsRng;
+use rand::RngCore;
 
 use subtle::*;
 
@@ -280,4 +284,50 @@ fn unwrap_none_ctoption() {
     // This test might fail (in release mode?) if the
     // compiler decides to optimize it away.
     CtOption::new(10, Choice::from(0)).unwrap();
+}
+
+macro_rules! generate_greater_than_test {
+    ($ty: ty) => {
+        for _ in 0..100 {
+            let x = OsRng.next_u64() as $ty;
+            let y = OsRng.next_u64() as $ty;
+            let z = x.ct_gt(&y);
+
+            println!("x={}, y={}, z={:?}", x, y, z);
+
+            if x < y {
+                assert!(z.unwrap_u8() == 0);
+            } else if x == y {
+                assert!(z.unwrap_u8() == 0);
+            } else if x > y {
+                assert!(z.unwrap_u8() == 1);
+            }
+        }
+    }
+}
+
+#[test]
+fn greater_than_u8() {
+    generate_greater_than_test!(u8);
+}
+
+#[test]
+fn greater_than_u16() {
+    generate_greater_than_test!(u16);
+}
+
+#[test]
+fn greater_than_u32() {
+    generate_greater_than_test!(u32);
+}
+
+#[test]
+fn greater_than_u64() {
+    generate_greater_than_test!(u64);
+}
+
+#[cfg(feature = "i128")]
+#[test]
+fn greater_than_u128() {
+    generate_greater_than_test!(u128);
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -331,3 +331,59 @@ fn greater_than_u64() {
 fn greater_than_u128() {
     generate_greater_than_test!(u128);
 }
+
+#[test]
+/// Test that the two's compliment min and max, i.e. 0000...0001 < 1111...1110,
+/// gives the correct result. (This fails using the bit-twiddling algorithm that
+/// go/crypto/subtle uses.)
+fn less_than_twos_compliment_minmax() {
+    let z = 1u32.ct_lt(&(2u32.pow(31)-1));
+
+    assert!(z.unwrap_u8() == 1);
+}
+
+macro_rules! generate_less_than_test {
+    ($ty: ty) => {
+        for _ in 0..100 {
+            let x = OsRng.next_u64() as $ty;
+            let y = OsRng.next_u64() as $ty;
+            let z = x.ct_gt(&y);
+
+            println!("x={}, y={}, z={:?}", x, y, z);
+
+            if x < y {
+                assert!(z.unwrap_u8() == 0);
+            } else if x == y {
+                assert!(z.unwrap_u8() == 0);
+            } else if x > y {
+                assert!(z.unwrap_u8() == 1);
+            }
+        }
+    }
+}
+
+#[test]
+fn less_than_u8() {
+    generate_less_than_test!(u8);
+}
+
+#[test]
+fn less_than_u16() {
+    generate_less_than_test!(u16);
+}
+
+#[test]
+fn less_than_u32() {
+    generate_less_than_test!(u32);
+}
+
+#[test]
+fn less_than_u64() {
+    generate_less_than_test!(u64);
+}
+
+#[cfg(feature = "i128")]
+#[test]
+fn less_than_u128() {
+    generate_less_than_test!(u128);
+}


### PR DESCRIPTION
This would help implementers of some post-quantum algorithms which require constant-time sorting networks (such as lattice-based key exchanges [where strong anonymity guarantees are required](https://lists.torproject.org/pipermail/tor-dev/2016-May/010908.html)). Additionally, I think it helps some ancient outdated mode of RSA padding or something, but I don't really care about that. (cf. #20)

I also began implementing a ConstantTimePartialOrd based using these two traits (see #79) and using the `greater_than + greater_than - less_than - 1` trick that libsodium uses in `sodium_compare()` for unsigned integers, but I can't find a way to use Rust's `Ordering` structs without branching on the result, so while I'm posting the code for reference, it should absolutely not be merged.

This should close #61, I believe.