### PR TITLE
[DO NOT MERGE] Attempt at making a constant-time PartialOrd impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ exclude = [
 [badges]
 travis-ci = { repository = "dalek-cryptography/subtle", branch = "master"}
 
+[dev-dependencies]
+rand = { version = "0.7" }
+
 [features]
 default = ["std", "i128"]
 std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -744,3 +744,17 @@ generate_unsigned_integer_greater_than!(u32, 32);
 generate_unsigned_integer_greater_than!(u64, 64);
 #[cfg(feature = "i128")]
 generate_unsigned_integer_greater_than!(u128, 128);
+
+pub trait ConstantTimeLessThan: ConstantTimeEq + ConstantTimeGreaterThan {
+    #[inline]
+    fn ct_lt(&self, other: &Self) -> Choice {
+        !self.ct_gt(other) & !self.ct_eq(other)
+    }
+}
+
+impl ConstantTimeLessThan for u8 {}
+impl ConstantTimeLessThan for u16 {}
+impl ConstantTimeLessThan for u32 {}
+impl ConstantTimeLessThan for u64 {}
+#[cfg(feature = "i128")]
+impl ConstantTimeLessThan for u128 {}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,4 +1,8 @@
+extern crate rand;
 extern crate subtle;
+
+use rand::rngs::OsRng;
+use rand::RngCore;
 
 use subtle::*;
 
@@ -280,4 +284,50 @@ fn unwrap_none_ctoption() {
     // This test might fail (in release mode?) if the
     // compiler decides to optimize it away.
     CtOption::new(10, Choice::from(0)).unwrap();
+}
+
+macro_rules! generate_greater_than_test {
+    ($ty: ty) => {
+        for _ in 0..100 {
+            let x = OsRng.next_u64() as $ty;
+            let y = OsRng.next_u64() as $ty;
+            let z = x.ct_gt(&y);
+
+            println!("x={}, y={}, z={:?}", x, y, z);
+
+            if x < y {
+                assert!(z.unwrap_u8() == 0);
+            } else if x == y {
+                assert!(z.unwrap_u8() == 0);
+            } else if x > y {
+                assert!(z.unwrap_u8() == 1);
+            }
+        }
+    }
+}
+
+#[test]
+fn greater_than_u8() {
+    generate_greater_than_test!(u8);
+}
+
+#[test]
+fn greater_than_u16() {
+    generate_greater_than_test!(u16);
+}
+
+#[test]
+fn greater_than_u32() {
+    generate_greater_than_test!(u32);
+}
+
+#[test]
+fn greater_than_u64() {
+    generate_greater_than_test!(u64);
+}
+
+#[cfg(feature = "i128")]
+#[test]
+fn greater_than_u128() {
+    generate_greater_than_test!(u128);
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -331,3 +331,59 @@ fn greater_than_u64() {
 fn greater_than_u128() {
     generate_greater_than_test!(u128);
 }
+
+#[test]
+/// Test that the two's compliment min and max, i.e. 0000...0001 < 1111...1110,
+/// gives the correct result. (This fails using the bit-twiddling algorithm that
+/// go/crypto/subtle uses.)
+fn less_than_twos_compliment_minmax() {
+    let z = 1u32.ct_lt(&(2u32.pow(31)-1));
+
+    assert!(z.unwrap_u8() == 1);
+}
+
+macro_rules! generate_less_than_test {
+    ($ty: ty) => {
+        for _ in 0..100 {
+            let x = OsRng.next_u64() as $ty;
+            let y = OsRng.next_u64() as $ty;
+            let z = x.ct_gt(&y);
+
+            println!("x={}, y={}, z={:?}", x, y, z);
+
+            if x < y {
+                assert!(z.unwrap_u8() == 0);
+            } else if x == y {
+                assert!(z.unwrap_u8() == 0);
+            } else if x > y {
+                assert!(z.unwrap_u8() == 1);
+            }
+        }
+    }
+}
+
+#[test]
+fn less_than_u8() {
+    generate_less_than_test!(u8);
+}
+
+#[test]
+fn less_than_u16() {
+    generate_less_than_test!(u16);
+}
+
+#[test]
+fn less_than_u32() {
+    generate_less_than_test!(u32);
+}
+
+#[test]
+fn less_than_u64() {
+    generate_less_than_test!(u64);
+}
+
+#[cfg(feature = "i128")]
+#[test]
+fn less_than_u128() {
+    generate_less_than_test!(u128);
+}


### PR DESCRIPTION
I don't actually like this approach because there's no way to get the integration with all of Rust's functionality through the `Ordering::{Less,Equal,Greater}` enum without branching on whether the value is -1, 0, or 1.  Because Ordering is implemented internally with i8s:

```rust
    pub enum Ordering {
        Less = -1,
        Equal = 0,
        Greater = 1,
    }
```

I assumed we could just construct an Ordering like so:

```rust
    let x = -1;
    let cmp = Ordering(x);

    assert!(::std::matches!(cmp, Ordering::Less {..} ));
```

But that turns out to not be the case?  If it is, then I don't see a clear way to make this constant-time.