### PR TITLE
Replace nightly feature with nightly-docs feature to avoid confusion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,11 @@ rust:
 
 matrix:
   include:
-    # Test nightly feature
-    - rust: nightly
-      env: NAME="nightly feature"
-      script: cargo test --features nightly
     # Test MSRV
     - rust: 1.41.0
       env: NAME="MSRV test"
       script: cargo test --no-default-features --features std
+
     # Test if crate can be truly built without std
     - env: TARGET=thumbv7em-none-eabi
       script: cargo build --no-default-features --target $TARGET

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ travis-ci = { repository = "dalek-cryptography/subtle", branch = "master"}
 default = ["std", "i128"]
 std = []
 i128 = []
-nightly = []
+nightly-docs = []

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,6 @@ cargo-fuzz = true
 
 [dependencies.subtle]
 path = ".."
-features = ["nightly"]
 [dependencies.libfuzzer-sys]
 git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,9 @@
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
 #![no_std]
-#![cfg_attr(feature = "nightly", feature(external_doc))]
-#![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
-#![cfg_attr(feature = "nightly", deny(missing_docs))]
+#![cfg_attr(feature = "nightly-docs", feature(external_doc))]
+#![cfg_attr(feature = "nightly-docs", doc(include = "../README.md"))]
+#![deny(missing_docs)]
 #![doc(html_logo_url = "https://doc.dalek.rs/assets/dalek-logo-clear.png")]
 #![doc(html_root_url = "https://docs.rs/subtle/2.3.0")]
 
@@ -56,7 +56,7 @@ impl Choice {
     ///
     /// **To convert a `Choice` to a `bool`, use the `From` implementation instead.**
     #[inline]
-    pub fn unwrap_u8(&self) -> u8 {
+    pub fn unwrap_u8(self) -> u8 {
         self.0
     }
 }
@@ -192,7 +192,6 @@ pub trait ConstantTimeEq {
     ///
     /// * `Choice(1u8)` if `self == other`;
     /// * `Choice(0u8)` if `self != other`.
-    #[inline]
     fn ct_eq(&self, other: &Self) -> Choice;
 }
 
@@ -305,7 +304,6 @@ pub trait ConditionallySelectable: Copy {
     /// # extern crate subtle;
     /// use subtle::ConditionallySelectable;
     /// #
-    /// # fn main() {
     /// let x: u8 = 13;
     /// let y: u8 = 42;
     ///
@@ -313,9 +311,7 @@ pub trait ConditionallySelectable: Copy {
     /// assert_eq!(z, x);
     /// let z = u8::conditional_select(&x, &y, 1.into());
     /// assert_eq!(z, y);
-    /// # }
     /// ```
-    #[inline]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self;
 
     /// Conditionally assign `other` to `self`, according to `choice`.
@@ -328,7 +324,6 @@ pub trait ConditionallySelectable: Copy {
     /// # extern crate subtle;
     /// use subtle::ConditionallySelectable;
     /// #
-    /// # fn main() {
     /// let mut x: u8 = 13;
     /// let mut y: u8 = 42;
     ///
@@ -336,7 +331,6 @@ pub trait ConditionallySelectable: Copy {
     /// assert_eq!(x, 13);
     /// x.conditional_assign(&y, 1.into());
     /// assert_eq!(x, 42);
-    /// # }
     /// ```
     #[inline]
     fn conditional_assign(&mut self, other: &Self, choice: Choice) {
@@ -354,7 +348,6 @@ pub trait ConditionallySelectable: Copy {
     /// # extern crate subtle;
     /// use subtle::ConditionallySelectable;
     /// #
-    /// # fn main() {
     /// let mut x: u8 = 13;
     /// let mut y: u8 = 42;
     ///
@@ -364,7 +357,6 @@ pub trait ConditionallySelectable: Copy {
     /// u8::conditional_swap(&mut x, &mut y, 1.into());
     /// assert_eq!(x, 42);
     /// assert_eq!(y, 13);
-    /// # }
     /// ```
     #[inline]
     fn conditional_swap(a: &mut Self, b: &mut Self, choice: Choice) {
@@ -465,7 +457,6 @@ pub trait ConditionallyNegatable {
     /// unchanged.
     ///
     /// This function should execute in constant time.
-    #[inline]
     fn conditional_negate(&mut self, choice: Choice);
 }
 
@@ -535,8 +526,8 @@ impl<T> CtOption<T> {
     #[inline]
     pub fn new(value: T, is_some: Choice) -> CtOption<T> {
         CtOption {
-            value: value,
-            is_some: is_some,
+            value,
+            is_some,
         }
     }
 


### PR DESCRIPTION
The title says it all, honestly. While looking into what the `nightly` feature of `subtle` added for `snow`, I found that the inline assembly was removed entirely, so the feature was only being used so the `README.md` could be included in the docs.

This removes the feature and replaces it with a `nightly_docs` feature to be more clear and then removes the usages of it in the fuzzer and Travis CI as they aren't used/needed anymore.

I wanted to add a note about this renaming to the README but I wasn't sure if I should/needed to.

I also resolved some warnings that Clippy was giving me. I tested the lints on the MSRV with `cargo +1.41.0-x86_64-pc-windows-msvc clippy` to ensure it wasn't just a new one added since. I'm not glued to them being here so if whomever reviews this doesn't want the lint fixes, I'll happily undo them and fix my commit.