### PR TITLE
Add constants representing Choice(1) and Choice(0)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,9 @@ use core::option::Option;
 #[derive(Copy, Clone, Debug)]
 pub struct Choice(u8);
 
+pub const CTRUE: Choice = Choice(1);
+pub const CFALSE: Choice = Choice(0);
+
 impl Choice {
     /// Unwrap the `Choice` wrapper to reveal the underlying `u8`.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,11 @@ use core::option::Option;
 #[derive(Copy, Clone, Debug)]
 pub struct Choice(u8);
 
-pub const CTRUE: Choice = Choice(1);
-pub const CFALSE: Choice = Choice(0);
+/// A constant representing the value True
+pub const TRUE: Choice = Choice(1);
+
+/// A constant representing the value False
+pub const FALSE: Choice = Choice(0);
 
 impl Choice {
     /// Unwrap the `Choice` wrapper to reveal the underlying `u8`.


### PR DESCRIPTION
This becomes really helpful in some code like this:

```
fn my_complex_function(condition: Choice, ...) {

}
```

Because sometimes the caller, or test code, wants to pass `True`
or `False` as the value, but right now the only way to do that
is like `Choice::from(0)` or `0.into()`, which are both harder
to read than `TRUE` or `FALSE`.