### PR TITLE
Conditionally select usize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,6 +393,9 @@ macro_rules! to_signed_int {
     (u128) => {
         i128
     };
+    (usize) => {
+        isize
+    };
     (i8) => {
         i8
     };
@@ -407,6 +410,9 @@ macro_rules! to_signed_int {
     };
     (i128) => {
         i128
+    };
+    (isize) => {
+        isize
     };
 }
 
@@ -448,6 +454,7 @@ generate_integer_conditional_select!( u32  i32);
 generate_integer_conditional_select!( u64  i64);
 #[cfg(feature = "i128")]
 generate_integer_conditional_select!(u128 i128);
+generate_integer_conditional_select!(usize isize);
 
 impl ConditionallySelectable for Choice {
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,6 @@ pub trait ConstantTimeEq {
     ///
     /// * `Choice(1u8)` if `self == other`;
     /// * `Choice(0u8)` if `self != other`.
-    #[inline]
     fn ct_eq(&self, other: &Self) -> Choice;
 }
 
@@ -318,7 +317,6 @@ pub trait ConditionallySelectable: Copy {
     /// assert_eq!(z, y);
     /// # }
     /// ```
-    #[inline]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self;
 
     /// Conditionally assign `other` to `self`, according to `choice`.
@@ -475,7 +473,6 @@ pub trait ConditionallyNegatable {
     /// unchanged.
     ///
     /// This function should execute in constant time.
-    #[inline]
     fn conditional_negate(&mut self, choice: Choice);
 }
 
@@ -544,10 +541,7 @@ impl<T> CtOption<T> {
     /// exposed.
     #[inline]
     pub fn new(value: T, is_some: Choice) -> CtOption<T> {
-        CtOption {
-            value: value,
-            is_some: is_some,
-        }
+        CtOption { value, is_some }
     }
 
     /// This returns the underlying value but panics if it


### PR DESCRIPTION
Background is an RSA implementation I'm writing, where I'm using `type Digit = usize`.

I presume lack of implementation for usize/isize was an oversight, not intentional?