### PR TITLE
drop `external_doc` feature gate usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
 #![no_std]
-#![cfg_attr(feature = "nightly", feature(external_doc))]
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 #![cfg_attr(feature = "nightly", deny(missing_docs))]
 #![doc(html_logo_url = "https://doc.dalek.rs/assets/dalek-logo-clear.png")]


### PR DESCRIPTION
The feature no longer exists on nightly.