### PR TITLE
Update to Rust 2018 Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 travis-ci = { repository = "dalek-cryptography/subtle", branch = "master"}
 
 [dev-dependencies]
-rand = { version = "0.7" }
+rand = { version = "0.8" }
 
 [features]
 default = ["std", "i128"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ name = "subtle"
 # - update README if necessary by semver
 # - if any updates were made to the README, also update the module documentation in src/lib.rs
 version = "2.4.1"
+edition = "2018"
 authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
            "Henry de Valence <hdevalence@hdevalence.ca>"]
 readme = "README.md"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,9 +1,9 @@
-
 [package]
 name = "subtle-fuzz"
 version = "0.0.1"
 authors = ["Automatically generated"]
 publish = false
+edition = "2018"
 
 [package.metadata]
 cargo-fuzz = true
@@ -11,8 +11,9 @@ cargo-fuzz = true
 [dependencies.subtle]
 path = ".."
 features = ["nightly"]
-[dependencies.libfuzzer-sys]
-git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+[dependencies]
+libfuzzer-sys = "0.4"
 
 # Prevent this from interfering with workspaces
 [workspace]
@@ -21,15 +22,23 @@ members = ["."]
 [[bin]]
 name = "conditional_assign_u8"
 path = "fuzzers/conditional_assign_u8.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "conditional_assign_u16"
 path = "fuzzers/conditional_assign_u16.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "conditional_assign_i8"
 path = "fuzzers/conditional_assign_i8.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "conditional_assign_i128"
 path = "fuzzers/conditional_assign_i128.rs"
+test = false
+doc = false

--- a/fuzz/fuzzers/conditional_assign_i128.rs
+++ b/fuzz/fuzzers/conditional_assign_i128.rs
@@ -1,12 +1,6 @@
 #![no_main]
-
-#[macro_use]
-extern crate libfuzzer_sys;
-extern crate subtle;
-extern crate core;
-
+use libfuzzer_sys::fuzz_target;
 use core::intrinsics::transmute;
-
 use subtle::ConditionallySelectable;
 
 fuzz_target!(|data: &[u8]| {
@@ -20,10 +14,10 @@ fuzz_target!(|data: &[u8]| {
         unsafe {
             let mut x: i128 = 0;
             let y: i128 = transmute::<[u8; 16], i128>([
-                bytes[0],  bytes[1],  bytes[2],  bytes[3],
-                bytes[4],  bytes[5],  bytes[6],  bytes[7],
-                bytes[8],  bytes[9],  bytes[10], bytes[11],
-                bytes[12], bytes[13], bytes[14], bytes[15]]);
+                bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+                bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14],
+                bytes[15],
+            ]);
 
             x.conditional_assign(&y, 0.into());
             assert_eq!(x, 0);

--- a/fuzz/fuzzers/conditional_assign_i8.rs
+++ b/fuzz/fuzzers/conditional_assign_i8.rs
@@ -1,12 +1,6 @@
 #![no_main]
-
-#[macro_use]
-extern crate libfuzzer_sys;
-extern crate subtle;
-extern crate core;
-
+use libfuzzer_sys::fuzz_target;
 use core::intrinsics::transmute;
-
 use subtle::ConditionallySelectable;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzzers/conditional_assign_u16.rs
+++ b/fuzz/fuzzers/conditional_assign_u16.rs
@@ -1,12 +1,6 @@
 #![no_main]
-
-#[macro_use]
-extern crate libfuzzer_sys;
-extern crate subtle;
-extern crate core;
-
+use libfuzzer_sys::fuzz_target;
 use core::intrinsics::transmute;
-
 use subtle::ConditionallySelectable;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzzers/conditional_assign_u8.rs
+++ b/fuzz/fuzzers/conditional_assign_u8.rs
@@ -1,10 +1,5 @@
 #![no_main]
-
-#[macro_use]
-extern crate libfuzzer_sys;
-extern crate subtle;
-extern crate core;
-
+use libfuzzer_sys::fuzz_target;
 use subtle::ConditionallySelectable;
 
 fuzz_target!(|data: &[u8]| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -597,8 +597,8 @@ impl<T> CtOption<T> {
     #[inline]
     pub fn new(value: T, is_some: Choice) -> CtOption<T> {
         CtOption {
-            value: value,
-            is_some: is_some,
+            value,
+            is_some,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -593,10 +593,7 @@ impl<T> CtOption<T> {
     /// exposed.
     #[inline]
     pub fn new(value: T, is_some: Choice) -> CtOption<T> {
-        CtOption {
-            value,
-            is_some,
-        }
+        CtOption { value, is_some }
     }
 
     /// This returns the underlying value but panics if it
@@ -794,7 +791,7 @@ macro_rules! generate_unsigned_integer_greater {
                 Choice::from((bit & 1) as u8)
             }
         }
-    }
+    };
 }
 
 generate_unsigned_integer_greater!(u8, 8);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,7 +366,6 @@ pub trait ConditionallySelectable: Copy {
     /// # Example
     ///
     /// ```
-    /// # extern crate subtle;
     /// use subtle::ConditionallySelectable;
     /// #
     /// # fn main() {
@@ -388,7 +387,6 @@ pub trait ConditionallySelectable: Copy {
     /// # Example
     ///
     /// ```
-    /// # extern crate subtle;
     /// use subtle::ConditionallySelectable;
     /// #
     /// # fn main() {
@@ -414,7 +412,6 @@ pub trait ConditionallySelectable: Copy {
     /// # Example
     ///
     /// ```
-    /// # extern crate subtle;
     /// use subtle::ConditionallySelectable;
     /// #
     /// # fn main() {
@@ -745,7 +742,6 @@ pub trait ConstantTimeGreater {
     /// # Example
     ///
     /// ```
-    /// # extern crate subtle;
     /// use subtle::ConstantTimeGreater;
     ///
     /// let x: u8 = 13;
@@ -829,7 +825,6 @@ pub trait ConstantTimeLess: ConstantTimeEq + ConstantTimeGreater {
     /// # Example
     ///
     /// ```
-    /// # extern crate subtle;
     /// use subtle::ConstantTimeLess;
     ///
     /// let x: u8 = 13;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,6 @@ pub trait ConstantTimeEq {
     ///
     /// * `Choice(1u8)` if `self == other`;
     /// * `Choice(0u8)` if `self != other`.
-    #[inline]
     fn ct_eq(&self, other: &Self) -> Choice;
 }
 
@@ -380,7 +379,6 @@ pub trait ConditionallySelectable: Copy {
     /// assert_eq!(z, y);
     /// # }
     /// ```
-    #[inline]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self;
 
     /// Conditionally assign `other` to `self`, according to `choice`.
@@ -434,7 +432,7 @@ pub trait ConditionallySelectable: Copy {
     #[inline]
     fn conditional_swap(a: &mut Self, b: &mut Self, choice: Choice) {
         let t: Self = *a;
-        a.conditional_assign(&b, choice);
+        a.conditional_assign(b, choice);
         b.conditional_assign(&t, choice);
     }
 }
@@ -530,7 +528,6 @@ pub trait ConditionallyNegatable {
     /// unchanged.
     ///
     /// This function should execute in constant time.
-    #[inline]
     fn conditional_negate(&mut self, choice: Choice);
 }
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -263,16 +263,66 @@ fn test_ctoption() {
     ));
 
     // Test (in)equality
-    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(1, Choice::from(1))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(1, Choice::from(0))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(2, Choice::from(1))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(2, Choice::from(0))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(1, Choice::from(0))).unwrap_u8() == 1);
-    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(2, Choice::from(0))).unwrap_u8() == 1);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(2, Choice::from(1))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(2, Choice::from(1))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(1, Choice::from(1))).unwrap_u8() == 1);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(1, Choice::from(1))).unwrap_u8() == 1);
+    assert!(
+        CtOption::new(1, Choice::from(0))
+            .ct_eq(&CtOption::new(1, Choice::from(1)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(1, Choice::from(0)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(0))
+            .ct_eq(&CtOption::new(2, Choice::from(1)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(2, Choice::from(0)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(0))
+            .ct_eq(&CtOption::new(1, Choice::from(0)))
+            .unwrap_u8()
+            == 1
+    );
+    assert!(
+        CtOption::new(1, Choice::from(0))
+            .ct_eq(&CtOption::new(2, Choice::from(0)))
+            .unwrap_u8()
+            == 1
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(2, Choice::from(1)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(2, Choice::from(1)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(1, Choice::from(1)))
+            .unwrap_u8()
+            == 1
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(1, Choice::from(1)))
+            .unwrap_u8()
+            == 1
+    );
 }
 
 #[test]
@@ -300,7 +350,7 @@ macro_rules! generate_greater_than_test {
                 assert!(z.unwrap_u8() == 1);
             }
         }
-    }
+    };
 }
 
 #[test]
@@ -334,7 +384,7 @@ fn greater_than_u128() {
 /// gives the correct result. (This fails using the bit-twiddling algorithm that
 /// go/crypto/subtle uses.)
 fn less_than_twos_compliment_minmax() {
-    let z = 1u32.ct_lt(&(2u32.pow(31)-1));
+    let z = 1u32.ct_lt(&(2u32.pow(31) - 1));
 
     assert!(z.unwrap_u8() == 1);
 }
@@ -356,7 +406,7 @@ macro_rules! generate_less_than_test {
                 assert!(z.unwrap_u8() == 1);
             }
         }
-    }
+    };
 }
 
 #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,6 +1,3 @@
-extern crate rand;
-extern crate subtle;
-
 use rand::rngs::OsRng;
 use rand::RngCore;
 


### PR DESCRIPTION
This PR address some general updates:
* Upgrade `rand` dependency from `0.7` to `0.8`
* Use the Rust 2018 syntax, and update the relative documentation (removed `external crate` from code and doc)
* Update the fuzzer code to Rust 2018 syntax and update `libfuzzer-sys` to the latest public version.
* Fix two `clippy` warnings:
  * redundant field names in struct initialization
  * `#[inline]` is ignored on function prototypes