### PR TITLE
Adding signed int inequalities

### DIFF
--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -331,7 +331,31 @@ fn greater_than_u64() {
 fn greater_than_u128() {
     generate_greater_than_test!(u128);
 }
+#[test]
+fn greater_than_i8() {
+    generate_greater_than_test!(i8);
+}
 
+#[test]
+fn greater_than_i16() {
+    generate_greater_than_test!(i16);
+}
+
+#[test]
+fn greater_than_i32() {
+    generate_greater_than_test!(i32);
+}
+
+#[test]
+fn greater_than_i64() {
+    generate_greater_than_test!(i64);
+}
+
+#[cfg(feature = "i128")]
+#[test]
+fn greater_than_i128() {
+    generate_greater_than_test!(i128);
+}
 #[test]
 /// Test that the two's compliment min and max, i.e. 0000...0001 < 1111...1110,
 /// gives the correct result. (This fails using the bit-twiddling algorithm that

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -266,16 +266,66 @@ fn test_ctoption() {
     ));
 
     // Test (in)equality
-    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(1, Choice::from(1))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(1, Choice::from(0))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(2, Choice::from(1))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(2, Choice::from(0))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(1, Choice::from(0))).unwrap_u8() == 1);
-    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(2, Choice::from(0))).unwrap_u8() == 1);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(2, Choice::from(1))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(2, Choice::from(1))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(1, Choice::from(1))).unwrap_u8() == 1);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(1, Choice::from(1))).unwrap_u8() == 1);
+    assert!(
+        CtOption::new(1, Choice::from(0))
+            .ct_eq(&CtOption::new(1, Choice::from(1)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(1, Choice::from(0)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(0))
+            .ct_eq(&CtOption::new(2, Choice::from(1)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(2, Choice::from(0)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(0))
+            .ct_eq(&CtOption::new(1, Choice::from(0)))
+            .unwrap_u8()
+            == 1
+    );
+    assert!(
+        CtOption::new(1, Choice::from(0))
+            .ct_eq(&CtOption::new(2, Choice::from(0)))
+            .unwrap_u8()
+            == 1
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(2, Choice::from(1)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(2, Choice::from(1)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(1, Choice::from(1)))
+            .unwrap_u8()
+            == 1
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(1, Choice::from(1)))
+            .unwrap_u8()
+            == 1
+    );
 }
 
 #[test]
@@ -303,7 +353,7 @@ macro_rules! generate_greater_than_test {
                 assert!(z.unwrap_u8() == 1);
             }
         }
-    }
+    };
 }
 
 #[test]
@@ -361,7 +411,7 @@ fn greater_than_i128() {
 /// gives the correct result. (This fails using the bit-twiddling algorithm that
 /// go/crypto/subtle uses.)
 fn less_than_twos_compliment_minmax() {
-    let z = 1u32.ct_lt(&(2u32.pow(31)-1));
+    let z = 1u32.ct_lt(&(2u32.pow(31) - 1));
 
     assert!(z.unwrap_u8() == 1);
 }
@@ -383,7 +433,7 @@ macro_rules! generate_less_than_test {
                 assert!(z.unwrap_u8() == 1);
             }
         }
-    }
+    };
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

Adding signed integer comparison support. This is part of an [existing issue] (https://github.com/dalek-cryptography/subtle/issues/61) 

### In this PR
* Added generate_signed_integer_gt
* Formatted tests
* Added signed_integer_gt tests

< Ticket status, e.g. "fixes #issue number" > 
This is part of an [existing issue] (https://github.com/dalek-cryptography/subtle/issues/61). Potentially we could close it after this?
