### PR TITLE
Implement `ConditionallySelectable` for `[T; N]`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,9 @@ script:
     cargo test --no-default-features --features std &&
     cargo test --no-default-features --features "std i128" &&
     cargo test --no-default-features --features "std core_hint_black_box" &&
-    cargo test --no-default-features --features "std i128 core_hint_black_box"
+    cargo test --no-default-features --features "std const-generics" &&
+    cargo test --no-default-features --features "std i128 core_hint_black_box" &&
+    cargo test --no-default-features --features "std i128 core_hint_black_box const-generics"
 
 notifications:
   slack:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ travis-ci = { repository = "dalek-cryptography/subtle", branch = "master"}
 rand = { version = "0.7" }
 
 [features]
+const-generics = []
 core_hint_black_box = []
 default = ["std", "i128"]
 std = []

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Rust versions from 1.66 or higher support a new best-effort optimization
 barrier ([`core::hint::black_box`]).  To use the new optimization barrier,
 enable the `core_hint_black_box` feature.
 
+Rust versions from 1.51 or higher have const generics support. You may enable
+`const-generics` feautre to have `subtle` traits implemented for arrays `[T; N]`.
+
 Versions prior to `2.2` recommended use of the `nightly` feature to enable an
 optimization barrier; this is not required in versions `2.2` and above.
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,3 +33,7 @@ path = "fuzzers/conditional_assign_i8.rs"
 [[bin]]
 name = "conditional_assign_i128"
 path = "fuzzers/conditional_assign_i128.rs"
+
+[[bin]]
+name = "conditional_assign_array"
+path = "fuzzers/conditional_assign_array.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies.subtle]
 path = ".."
-features = ["nightly"]
+features = ["nightly", "const-generics"]
 [dependencies.libfuzzer-sys]
 git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
 

--- a/fuzz/fuzzers/conditional_assign_array.rs
+++ b/fuzz/fuzzers/conditional_assign_array.rs
@@ -1,0 +1,29 @@
+#![no_main]
+
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate subtle;
+extern crate core;
+
+use core::convert::TryFrom;
+
+use subtle::ConditionallySelectable;
+
+fuzz_target!(|data: &[u8]| {
+    let chunk_size: usize = 16;
+
+    if data.len() % chunk_size != 0 {
+        return;
+    }
+
+    for bytes in data.chunks(chunk_size) {
+        let mut x = [0u8; 16];
+        let y = <[u8; 16]>::try_from(bytes).unwrap();
+
+        x.conditional_assign(&y, 0.into());
+        assert_eq!(x, [0u8; 16]);
+
+        x.conditional_assign(&y, 1.into());
+        assert_eq!(x, y);
+    }
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,13 @@
 //! inner `u8` by passing it through a volatile read. For more information, see
 //! the _About_ section below.
 //!
+//! Rust versions from 1.66 or higher support a new best-effort optimization
+//! barrier ([`core::hint::black_box`]).  To use the new optimization barrier,
+//! enable the `core_hint_black_box` feature.
+//!
+//! Rust versions from 1.51 or higher have const generics support. You may enable
+//! `const-generics` feautre to have `subtle` traits implemented for arrays `[T; N]`.
+//!
 //! Versions prior to `2.2` recommended use of the `nightly` feature to enable an
 //! optimization barrier; this is not required in versions `2.2` and above.
 //!
@@ -55,7 +62,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.51** or higher.
+//! Rust **1.41** or higher.
 //!
 //! Minimum supported Rust version can be changed in the future, but it will be done with a minor version bump.
 //!
@@ -63,10 +70,15 @@
 //!
 //! This library aims to be the Rust equivalent of Go’s `crypto/subtle` module.
 //!
-//! The optimization barrier in `impl From<u8> for Choice` was based on Tim
-//! Maclean's [work on `rust-timing-shield`][rust-timing-shield], which attempts to
-//! provide a more comprehensive approach for preventing software side-channels in
-//! Rust code.
+//! Old versions of the optimization barrier in `impl From<u8> for Choice` were
+//! based on Tim Maclean's [work on `rust-timing-shield`][rust-timing-shield],
+//! which attempts to provide a more comprehensive approach for preventing
+//! software side-channels in Rust code.
+//!
+//! From version `2.2`, it was based on Diane Hosfelt and Amber Sprenkels' work on
+//! "Secret Types in Rust".  Version `2.3` adds the `core_hint_black_box` feature,
+//! which uses the original method through the [`core::hint::black_box`] function
+//! from the Rust standard library.
 //!
 //! `subtle` is authored by isis agora lovecruft and Henry de Valence.
 //!
@@ -81,6 +93,7 @@
 //! **USE AT YOUR OWN RISK**
 //!
 //! [docs]: https://docs.rs/subtle
+//! [`core::hint::black_box`]: https://doc.rust-lang.org/core/hint/fn.black_box.html
 //! [rust-timing-shield]: https://www.chosenplaintext.ca/open-source/rust-timing-shield/security
 
 #[cfg(feature = "std")]
@@ -856,7 +869,7 @@ macro_rules! generate_unsigned_integer_greater {
                 Choice::from((bit & 1) as u8)
             }
         }
-    }
+    };
 }
 
 generate_unsigned_integer_greater!(u8, 8);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.41** or higher.
+//! Rust **1.51** or higher.
 //!
 //! Minimum supported Rust version can be changed in the future, but it will be done with a minor version bump.
 //!
@@ -536,6 +536,23 @@ impl ConditionallySelectable for Choice {
     #[inline]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Choice(u8::conditional_select(&a.0, &b.0, choice))
+    }
+}
+
+impl<T, const N: usize> ConditionallySelectable for [T; N]
+where T: ConditionallySelectable
+{
+    #[inline]
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        let mut output = *a;
+        output.conditional_assign(b, choice);
+        output
+    }
+
+    fn conditional_assign(&mut self, other: &Self, choice: Choice) {
+        for (a_i, b_i) in self.iter_mut().zip(other) {
+            a_i.conditional_assign(b_i, choice)
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -539,8 +539,10 @@ impl ConditionallySelectable for Choice {
     }
 }
 
+#[cfg(feature = "const-generics")]
 impl<T, const N: usize> ConditionallySelectable for [T; N]
-where T: ConditionallySelectable
+where
+    T: ConditionallySelectable,
 {
     #[inline]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {


### PR DESCRIPTION
PR makes arrays of any size "conditionally selectable" as long as `T` is conditionally selectable. Changes MSRV to 1.51.

Closes #82 