### PR TITLE
Add `CtOption::expect`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,6 +605,18 @@ impl<T> CtOption<T> {
         }
     }
 
+    /// Returns the contained value, consuming the `self` value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is none with a custom panic message provided by
+    /// `msg`.
+    pub fn expect(self, msg: &str) -> T {
+        assert_eq!(self.is_some.unwrap_u8(), 1, "{}", msg);
+
+        self.value
+    }
+
     /// This returns the underlying value but panics if it
     /// is not `Some`.
     #[inline]


### PR DESCRIPTION
Along the lines of the existing `CtOption::unwrap`, this adds a corresponding `CtOption::expect` which works like `Option::expect`: unwraps the value if it's some, or else panics with a provided error message.

Using `expect` over `unwrap` is generally prefered from a Rust style perspective. This allows the caller to describe what invariant was violated when it's expected some `CtOption` is always some.