### PR TITLE
Add `ConstantTimeEq::ct_ne`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,19 @@ pub trait ConstantTimeEq {
     /// * `Choice(0u8)` if `self != other`.
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice;
+
+    /// Determine if two items are NOT equal.
+    ///
+    /// The `ct_ne` function should execute in constant time.
+    ///
+    /// # Returns
+    ///
+    /// * `Choice(0u8)` if `self == other`;
+    /// * `Choice(1u8)` if `self != other`.
+    #[inline]
+    fn ct_ne(&self, other: &Self) -> Choice {
+        !self.ct_eq(other)
+    }
 }
 
 impl<T: ConstantTimeEq> ConstantTimeEq for [T] {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -105,6 +105,8 @@ macro_rules! generate_integer_equal_tests {
 
         assert_eq!(x.ct_eq(&y).unwrap_u8(), 0);
         assert_eq!(x.ct_eq(&z).unwrap_u8(), 1);
+        assert_eq!(x.ct_ne(&y).unwrap_u8(), 1);
+        assert_eq!(x.ct_ne(&z).unwrap_u8(), 0);
     )*)
 }
 


### PR DESCRIPTION
Adds a provided `ct_ne` method to `ConstantTimeEq` which provides the inverse of `ct_eq`.