### PR TITLE
Revert new black_box optimization barrier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,8 @@ script:
   - cargo test && cargo test --no-default-features &&
     cargo test --no-default-features --features std &&
     cargo test --no-default-features --features "std i128" &&
-    cargo test --no-default-features --features "std core_hint_black_box" &&
     cargo test --no-default-features --features "std const-generics" &&
-    cargo test --no-default-features --features "std i128 core_hint_black_box" &&
-    cargo test --no-default-features --features "std i128 core_hint_black_box const-generics"
+    cargo test --no-default-features --features "std i128 const-generics"
 
 notifications:
   slack:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ rand = { version = "0.8" }
 
 [features]
 const-generics = []
+# DEPRECATED: As of 2.5.1, this feature does nothing.
 core_hint_black_box = []
 default = ["std", "i128"]
 std = []

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Documentation is available [here][docs].
 
 ## Minimum Supported Rust Version
 
-Rust **1.66** or higher.
+Rust **1.41** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be done with a minor version bump.
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ prevent this refinement, the crate tries to hide the value of a `Choice`'s
 inner `u8` by passing it through a volatile read. For more information, see
 the _About_ section below.
 
-Rust versions from 1.66 or higher support a new best-effort optimization
-barrier ([`core::hint::black_box`]).  To use the new optimization barrier,
-enable the `core_hint_black_box` feature.
-
 Rust versions from 1.51 or higher have const generics support. You may enable
 `const-generics` feautre to have `subtle` traits implemented for arrays `[T; N]`.
 
@@ -47,7 +43,7 @@ Documentation is available [here][docs].
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.66** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be done with a minor version bump.
 
@@ -59,11 +55,8 @@ Old versions of the optimization barrier in `impl From<u8> for Choice` were
 based on Tim Maclean's [work on `rust-timing-shield`][rust-timing-shield],
 which attempts to provide a more comprehensive approach for preventing
 software side-channels in Rust code.
-
 From version `2.2`, it was based on Diane Hosfelt and Amber Sprenkels' work on
-"Secret Types in Rust".  Version `2.5` adds the `core_hint_black_box` feature,
-which uses the original method through the [`core::hint::black_box`] function
-from the Rust standard library.
+"Secret Types in Rust".
 
 `subtle` is authored by isis agora lovecruft and Henry de Valence.
 
@@ -78,5 +71,4 @@ effort is fundamentally limited.
 **USE AT YOUR OWN RISK**
 
 [docs]: https://docs.rs/subtle
-[`core::hint::black_box`]: https://doc.rust-lang.org/core/hint/fn.black_box.html
 [rust-timing-shield]: https://www.chosenplaintext.ca/open-source/rust-timing-shield/security

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,6 @@ impl Not for Choice {
 impl From<u8> for Choice {
     #[inline]
     fn from(input: u8) -> Choice {
-        debug_assert!((input == 0u8) | (input == 1u8));
         // Our goal is to prevent the compiler from inferring that the value held inside the
         // resulting `Choice` struct is really an `i1` instead of an `i8`.
         Choice(core::hint::black_box(input))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,12 +206,39 @@ impl Not for Choice {
     }
 }
 
+/// This function is a best-effort attempt to prevent the compiler from knowing
+/// anything about the value of the returned `u8`, other than its type.
+///
+/// Because we want to support stable Rust, we don't have access to inline
+/// assembly or test::black_box, so we use the fact that volatile values will
+/// never be elided to register values.
+///
+/// Note: Rust's notion of "volatile" is subject to change over time. While this
+/// code may break in a non-destructive way in the future, “constant-time” code
+/// is a continually moving target, and this is better than doing nothing.
+#[inline(never)]
+fn black_box(input: u8) -> u8 {
+    debug_assert!((input == 0u8) | (input == 1u8));
+
+    unsafe {
+        // Optimization barrier
+        //
+        // Unsafe is ok, because:
+        //   - &input is not NULL;
+        //   - size of input is not zero;
+        //   - u8 is neither Sync, nor Send;
+        //   - u8 is Copy, so input is always live;
+        //   - u8 type is always properly aligned.
+        core::ptr::read_volatile(&input as *const u8)
+    }
+}
+
 impl From<u8> for Choice {
     #[inline]
     fn from(input: u8) -> Choice {
         // Our goal is to prevent the compiler from inferring that the value held inside the
         // resulting `Choice` struct is really an `i1` instead of an `i8`.
-        Choice(core::hint::black_box(input))
+        Choice(black_box(input))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ fn black_box(input: u8) -> u8 {
 }
 
 #[cfg(feature = "core_hint_black_box")]
-#[inline(never)]
+#[inline]
 fn black_box(input: u8) -> u8 {
     debug_assert!((input == 0u8) | (input == 1u8));
     core::hint::black_box(input)


### PR DESCRIPTION
In https://github.com/dalek-cryptography/subtle/pull/96#issuecomment-1450728097, @tarcieri noticed that recently the rustdoc documentation has added a big notice that `core::hint::black_box` should **not** be relied upon for correctness, especially for security or cryptographic purposes. It seems wise to revert that change. :(

Review suggestions:
* I kept the feature flag intact, but it is a no-op, to be removed at the next major version bump, to prevent builds from breaking.
