### PR TITLE
implement lexicographical ordering for slices of arbitrary types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -865,7 +865,7 @@ pub trait ConstantTimeGreater {
 macro_rules! generate_unsigned_integer_greater {
     ($t_u: ty, $bit_width: expr) => {
         impl ConstantTimeGreater for $t_u {
-            /// Returns Choice::from(1) iff x > y, and Choice::from(0) iff x <= y.
+            /// Returns Choice::from(1) if x > y, and Choice::from(0) if x <= y.
             ///
             /// # Note
             ///

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -290,16 +290,66 @@ fn test_ctoption() {
     ));
 
     // Test (in)equality
-    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(1, Choice::from(1))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(1, Choice::from(0))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(2, Choice::from(1))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(2, Choice::from(0))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(1, Choice::from(0))).unwrap_u8() == 1);
-    assert!(CtOption::new(1, Choice::from(0)).ct_eq(&CtOption::new(2, Choice::from(0))).unwrap_u8() == 1);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(2, Choice::from(1))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(2, Choice::from(1))).unwrap_u8() == 0);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(1, Choice::from(1))).unwrap_u8() == 1);
-    assert!(CtOption::new(1, Choice::from(1)).ct_eq(&CtOption::new(1, Choice::from(1))).unwrap_u8() == 1);
+    assert!(
+        CtOption::new(1, Choice::from(0))
+            .ct_eq(&CtOption::new(1, Choice::from(1)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(1, Choice::from(0)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(0))
+            .ct_eq(&CtOption::new(2, Choice::from(1)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(2, Choice::from(0)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(0))
+            .ct_eq(&CtOption::new(1, Choice::from(0)))
+            .unwrap_u8()
+            == 1
+    );
+    assert!(
+        CtOption::new(1, Choice::from(0))
+            .ct_eq(&CtOption::new(2, Choice::from(0)))
+            .unwrap_u8()
+            == 1
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(2, Choice::from(1)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(2, Choice::from(1)))
+            .unwrap_u8()
+            == 0
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(1, Choice::from(1)))
+            .unwrap_u8()
+            == 1
+    );
+    assert!(
+        CtOption::new(1, Choice::from(1))
+            .ct_eq(&CtOption::new(1, Choice::from(1)))
+            .unwrap_u8()
+            == 1
+    );
 }
 
 #[test]
@@ -327,7 +377,7 @@ macro_rules! generate_greater_than_test {
                 assert!(z.unwrap_u8() == 1);
             }
         }
-    }
+    };
 }
 
 #[test]
@@ -358,8 +408,18 @@ fn greater_than_u128() {
 
 #[test]
 fn greater_than_ordering() {
-    assert_eq!(cmp::Ordering::Less.ct_gt(&cmp::Ordering::Greater).unwrap_u8(), 0);
-    assert_eq!(cmp::Ordering::Greater.ct_gt(&cmp::Ordering::Less).unwrap_u8(), 1);
+    assert_eq!(
+        cmp::Ordering::Less
+            .ct_gt(&cmp::Ordering::Greater)
+            .unwrap_u8(),
+        0
+    );
+    assert_eq!(
+        cmp::Ordering::Greater
+            .ct_gt(&cmp::Ordering::Less)
+            .unwrap_u8(),
+        1
+    );
 }
 
 #[test]
@@ -367,7 +427,7 @@ fn greater_than_ordering() {
 /// gives the correct result. (This fails using the bit-twiddling algorithm that
 /// go/crypto/subtle uses.)
 fn less_than_twos_compliment_minmax() {
-    let z = 1u32.ct_lt(&(2u32.pow(31)-1));
+    let z = 1u32.ct_lt(&(2u32.pow(31) - 1));
 
     assert!(z.unwrap_u8() == 1);
 }
@@ -389,7 +449,7 @@ macro_rules! generate_less_than_test {
                 assert!(z.unwrap_u8() == 1);
             }
         }
-    }
+    };
 }
 
 #[test]
@@ -420,6 +480,16 @@ fn less_than_u128() {
 
 #[test]
 fn less_than_ordering() {
-    assert_eq!(cmp::Ordering::Greater.ct_lt(&cmp::Ordering::Less).unwrap_u8(), 0);
-    assert_eq!(cmp::Ordering::Less.ct_lt(&cmp::Ordering::Greater).unwrap_u8(), 1);
+    assert_eq!(
+        cmp::Ordering::Greater
+            .ct_lt(&cmp::Ordering::Less)
+            .unwrap_u8(),
+        0
+    );
+    assert_eq!(
+        cmp::Ordering::Less
+            .ct_lt(&cmp::Ordering::Greater)
+            .unwrap_u8(),
+        1
+    );
 }


### PR DESCRIPTION
This generalizes the implementation of `ConstantTimeEq` for `[T]` to also support `ConstantTimeGreater` and `ConstantTimeLess`. I haven't touched the implementation of `ConstantTimeEq for [T]` as the standalone implementation is more efficient than the multi-purpose code i've added here. However in principle the execution of the code is very similar.

I added a utility function `ct_slice_lex_cmp(x, y)` which produces a `cmp::Ordering` in time proportional to `min(x.len(), y.len())`. I chose this approach rather than implementing `ConstantTimeGreater` directly, because it allows us to also implement `ConstantTimeLess` without invoking both `ct_eq` and `ct_gt`, which would perform up to twice as many loop iterations over both slices.



## Reasoning


I wrote this PR because I found a need in my project for constant time comparison on fixed-size arrays of bytes (secret data), beyond simple equality checking. Specifically, I needed to check if an elliptic curve secret scalar value represented as `[u8; 32]` was larger than the curve order (some fixed `[u8; 32]` constant).

In non-constant time operations, one could simply do `x >= y`. I wrote `ct_slice_lex_cmp` to fulfill this duty and realized it might be handy upstream here. 

PS those formatting changes in `test/mod.rs` were automatically applied by `cargo fmt`. I can revert commit ca90794 if you'd prefer to keep that code formatted as it was before.