### PR TITLE
Remove ignored inline attributes from function prototypes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,6 @@ pub trait ConstantTimeEq {
     ///
     /// * `Choice(1u8)` if `self == other`;
     /// * `Choice(0u8)` if `self != other`.
-    #[inline]
     fn ct_eq(&self, other: &Self) -> Choice;
 
     /// Determine if two items are NOT equal.
@@ -422,7 +421,6 @@ pub trait ConditionallySelectable: Copy {
     /// assert_eq!(z, y);
     /// # }
     /// ```
-    #[inline]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self;
 
     /// Conditionally assign `other` to `self`, according to `choice`.
@@ -609,7 +607,6 @@ pub trait ConditionallyNegatable {
     /// unchanged.
     ///
     /// This function should execute in constant time.
-    #[inline]
     fn conditional_negate(&mut self, choice: Choice);
 }
 


### PR DESCRIPTION
Attributes that are in function prototypes are ignored and emit a compiler warning. This pull request should not have any effect except removing the compiler warnings:

```
warning: `#[inline]` is ignored on function prototypes
   --> /Users/oherrala/.cargo/registry/src/index.crates.io-6f17d22bba15001f/subtle-2.5.0/src/lib.rs:282:5
    |
282 |     #[inline]
    |     ^^^^^^^^^
    |
    = note: `#[warn(unused_attributes)]` on by default

warning: `#[inline]` is ignored on function prototypes
   --> /Users/oherrala/.cargo/registry/src/index.crates.io-6f17d22bba15001f/subtle-2.5.0/src/lib.rs:425:5
    |
425 |     #[inline]
    |     ^^^^^^^^^

warning: `#[inline]` is ignored on function prototypes
   --> /Users/oherrala/.cargo/registry/src/index.crates.io-6f17d22bba15001f/subtle-2.5.0/src/lib.rs:612:5
    |
612 |     #[inline]
    |     ^^^^^^^^^

warning: `subtle` (lib) generated 3 warnings
```

