### PR TITLE
Restore 1.60 MSRV and fix build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.41.0
+          - 1.60.0
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,7 @@ impl Not for Choice {
 /// Note: Rust's notion of "volatile" is subject to change over time. While this
 /// code may break in a non-destructive way in the future, “constant-time” code
 /// is a continually moving target, and this is better than doing nothing.
+#[cfg(not(feature = "core_hint_black_box"))]
 #[inline(never)]
 fn black_box<T: Copy>(input: T) -> T {
     unsafe {
@@ -996,7 +997,7 @@ impl<T: Copy> BlackBox<T> {
     /// Constructs a new instance of `BlackBox` which will wrap the specified value.
     ///
     /// All access to the inner value will be mediated by a `black_box` optimization barrier.
-    pub const fn new(value: T) -> Self {
+    pub fn new(value: T) -> Self {
         Self(value)
     }
 


### PR DESCRIPTION
Seems some changes I force pushed to #123 didn't wind up getting merged. In that PR, I noted that `pub const fn new` was MSRV breaking and got rid of the `const` but that didn't end up in `develop`.

I also encountered a build failure on `develop` since the legacy `black_box` function wasn't gated on the `core_hint_black_box` feature and thus clashed with `core::hint::black_box` when it was imported:

```
   Compiling subtle v2.6.0 (/Users/tarcieri/src/subtle)
error[E0255]: the name `black_box` is defined multiple times
   --> src/lib.rs:223:1
    |
100 | use core::hint::black_box;
    |     --------------------- previous import of the value `black_box` here
...
223 | fn black_box<T: Copy>(input: T) -> T {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `black_box` redefined here
    |
    = note: `black_box` must be defined only once in the value namespace of this module
help: you can use `as` to change the binding name of the import
    |
100 | use core::hint::black_box as other_black_box;
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: unused import: `core::hint::black_box`
   --> src/lib.rs:100:5
    |
100 | use core::hint::black_box;
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default
```

This is a breaking change since we shipped a `const fn` for `BlackBox::new` already, so I'd suggest releasing this as 2.6.1 and yanking 2.6.0 for being unintentionally MSRV breaking.