### PR TITLE
Don't define black_box when core_hint_black_box feature enabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,7 @@ impl Not for Choice {
 /// Note: Rust's notion of "volatile" is subject to change over time. While this
 /// code may break in a non-destructive way in the future, “constant-time” code
 /// is a continually moving target, and this is better than doing nothing.
+#[cfg(not(feature = "core_hint_black_box"))]
 #[inline(never)]
 fn black_box<T: Copy>(input: T) -> T {
     unsafe {


### PR DESCRIPTION
Fixes #126 