### PR TITLE
Remove incorrect comment about core_hint_black_box

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ rand = { version = "0.8" }
 
 [features]
 const-generics = []
-# DEPRECATED: As of 2.5.1, this feature does nothing.
 core_hint_black_box = []
 default = ["std", "i128"]
 std = []


### PR DESCRIPTION
This removes a comment from `Cargo.toml` on the `core_hint_black_box` feature. Since #123 partially undid #107, the `core_hint_black_box` feature is still used.

FWIW, #107 also removed some documentation about the feature, but I figure that probably needs more wordsmithing before it is reintroduced, based on recent discussions.