### PR TITLE
Enable the `const-generics` feature on default and fix small cfg bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rand = { version = "0.8" }
 const-generics = []
 # DEPRECATED: As of 2.5.1, this feature does nothing.
 core_hint_black_box = []
-default = ["std", "i128"]
+default = ["std", "i128", "const-generics"]
 std = []
 i128 = []
 # DEPRECATED: As of 2.4.1, this feature does nothing.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,6 +220,7 @@ impl Not for Choice {
 /// code may break in a non-destructive way in the future, “constant-time” code
 /// is a continually moving target, and this is better than doing nothing.
 #[inline(never)]
+#[cfg(not(feature = "core_hint_black_box"))]
 fn black_box<T: Copy>(input: T) -> T {
     unsafe {
         // Optimization barrier


### PR DESCRIPTION
See: https://github.com/dalek-cryptography/curve25519-dalek/pull/677#discussion_r1695474151