### PR TITLE
Change `ConditionallySelectable` supertrait from `Copy` to `Sized`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "subtle"
 # - update html_root_url
 # - update README if necessary by semver
 # - if any updates were made to the README, also update the module documentation in src/lib.rs
-version = "2.6.0"
+version = "3.0.0-pre"
 edition = "2018"
 authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
            "Henry de Valence <hdevalence@hdevalence.ca>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,7 +390,7 @@ impl ConstantTimeEq for cmp::Ordering {
 //
 // #[inline] is specified on these function prototypes to signify that they
 #[allow(unused_attributes)] // should be in the actual implementation
-pub trait ConditionallySelectable: Copy {
+pub trait ConditionallySelectable: Sized {
     /// Select `a` or `b` according to `choice`.
     ///
     /// # Returns
@@ -467,9 +467,9 @@ pub trait ConditionallySelectable: Copy {
     /// ```
     #[inline]
     fn conditional_swap(a: &mut Self, b: &mut Self, choice: Choice) {
-        let t: Self = *a;
-        a.conditional_assign(&b, choice);
-        b.conditional_assign(&t, choice);
+        let t = Self::conditional_select(a, b, choice);
+        *b = Self::conditional_select(b, a, choice);
+        *a = t;
     }
 }
 
@@ -575,7 +575,7 @@ impl ConditionallySelectable for Choice {
 #[cfg(feature = "const-generics")]
 impl<T, const N: usize> ConditionallySelectable for [T; N]
 where
-    T: ConditionallySelectable,
+    T: ConditionallySelectable + Copy,
 {
     #[inline]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {


### PR DESCRIPTION
To resolve #94, removes the `Copy` supertrait bound on `ConditionallySelectable`, replacing it with `Sized` instead.

It turns out the bound is only used in the default implementation of `ConditionallySelectable::conditional_swap`, and is easy to replace by slightly changing that default implementation.

Removing this supertrait bound is arguably a breaking change since it means types which impl `ConditionallySelectable` can no longer be assumed to be `Copy`, so also bumps the version to `3.0.0-pre`.

Alternative to #118, #136