### PR TITLE
expect(): Track caller

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -687,6 +687,7 @@ impl<T> CtOption<T> {
     ///
     /// Panics if the value is none with a custom panic message provided by
     /// `msg`.
+    #[track_caller]
     pub fn expect(self, msg: &str) -> T {
         assert_eq!(self.is_some.unwrap_u8(), 1, "{}", msg);
 


### PR DESCRIPTION
The panic location printed by a panicking `.expect()` call is not helpful -- it points to subtle instead of the code that had the expectation.

I was lucky that the error message was usable in the message I got:

```
thread '<unnamed>' panicked at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/subtle-2.6.1/src/lib.rs:692:9:
assertion `left == right` failed: Public key is not a good point
  left: 0
 right: 1
```

but still had to look around a bit for where that came from precisely. With the annotation added in this PR, the compiler will make an effort to produce a more helpful location: the one expect()'s caller.

(Most other functions on this type are `#[inline]`, and I don't know whether or not inline also has that effect, but at any rate, this function is the one that describes a panic, and that's where `track_caller` is needed the most).