### PR TITLE
Add `#[track_caller]` to `CtOption::{expect, unwrap}`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -688,6 +688,7 @@ impl<T> CtOption<T> {
     ///
     /// Panics if the value is none with a custom panic message provided by
     /// `msg`.
+    #[track_caller]
     pub fn expect(self, msg: &str) -> T {
         assert_eq!(self.is_some.unwrap_u8(), 1, "{}", msg);
 
@@ -697,6 +698,7 @@ impl<T> CtOption<T> {
     /// This returns the underlying value but panics if it
     /// is not `Some`.
     #[inline]
+    #[track_caller]
     pub fn unwrap(self) -> T {
         assert_eq!(self.is_some.unwrap_u8(), 1);
 


### PR DESCRIPTION
This option adds a location hint about the function which called it, which is useful when debugging panics since otherwise unless you set `RUST_BACKTRACE` you instead get the line in `subtle` where a particular `assert!` failed, rather than the location of the call site into `expect` or `unwrap`.

See: https://doc.rust-lang.org/reference/attributes/codegen.html#the-track_caller-attribute

Closes #142 